### PR TITLE
UNNotification Extensions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [
-          macos-12, 
+          macos-14, 
 #         ubuntu-latest
         ]
         
@@ -20,7 +20,7 @@ jobs:
     
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       
     - name: Swift Build
       uses: SwiftActions/SwiftBuild@main

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "asyncplus",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/richardpiazza/AsyncPlus",
+      "state" : {
+        "revision" : "4e7b506142c6a268b2adac12b405615320bb04c8",
+        "version" : "0.3.1"
+      }
+    },
+    {
       "identity" : "harness",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/richardpiazza/Harness.git",
       "state" : {
-        "revision" : "5cadd677550b3aaf7a21739b2cc1f207726b84a2",
-        "version" : "1.0.0"
+        "revision" : "0fffad21894b52349c84dfdccb7e31e07019655f",
+        "version" : "1.2.0"
       }
     },
     {
@@ -14,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -18,15 +18,15 @@ let package = Package(
             name: "Notification",
             targets: [
                 "Notification",
-                "NotificationEmulation",
             ]
         ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.2")),
-        .package(url: "https://github.com/richardpiazza/Harness.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.4")),
+        .package(url: "https://github.com/richardpiazza/AsyncPlus.git", .upToNextMajor(from: "0.3.1")),
+        .package(url: "https://github.com/richardpiazza/Harness.git", .upToNextMajor(from: "1.2.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -35,12 +35,7 @@ let package = Package(
             name: "Notification",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
-            ]
-        ),
-        .target(
-            name: "NotificationEmulation",
-            dependencies: [
-                "Notification",
+                .product(name: "AsyncPlus", package: "AsyncPlus"),
                 .product(name: "Harness", package: "Harness"),
             ]
         ),
@@ -48,7 +43,6 @@ let package = Package(
             name: "NotificationTests",
             dependencies: [
                 "Notification",
-                "NotificationEmulation",
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A swift library for interacting with user notifications.
     <img src="https://github.com/richardpiazza/Notification/workflows/Swift/badge.svg?branch=main" />
 </p>
 
-_Note: The current implementation only works on **Apple** platforms, due to its heavy reliance on the **Combine** framework._
-
 ## Installation
 
 **Notification** is distributed using the [Swift Package Manager](https://swift.org/package-manager). To install it into a 
@@ -17,7 +15,7 @@ let package = Package(
     ...
     // Package Dependencies
     dependencies: [
-        .package(url: "https://github.com/richardpiazza/Notification.git", .upToNextMajor(from: "0.1.0"))
+        .package(url: "https://github.com/richardpiazza/Notification.git", .upToNextMajor(from: "1.1.0"))
     ],
     ...
     // Target Dependencies
@@ -29,11 +27,9 @@ let package = Package(
 
 ## Targets
 
-### Notifications
+### Notification
 
 Provides abstracted protocols and classes for interacting with Notification services.
 On Apple platforms this is the `UserNotifications` framework.
-
-### NotificationsEmulation
 
 Emulated classes that implement the protocols with basic functionality for mocking behavior (simulator).

--- a/Sources/Notification/AuthorizationStatus.swift
+++ b/Sources/Notification/AuthorizationStatus.swift
@@ -1,8 +1,7 @@
-import Foundation
-
 /// Alias to `AuthorizationStatus` to allow disambiguation when `Notification.AuthorizationStatus` cannot be used.
 public typealias NotificationAuthorizationStatus = AuthorizationStatus
 
+/// Indication of whether an app is allowed to schedule notifications.
 public enum AuthorizationStatus: Codable {
     /// The user has not yet made a choice regarding whether the application may post user notifications.
     case notDetermined
@@ -15,24 +14,3 @@ public enum AuthorizationStatus: Codable {
     /// The application is temporarily authorized to post notifications. Only available to app clips.
     case ephemeral
 }
-
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension AuthorizationStatus {
-    init(authorizationStatus: UNAuthorizationStatus) {
-        switch authorizationStatus {
-        case .denied:
-            self = .denied
-        case .authorized:
-            self = .authorized
-        case .provisional:
-            self = .provisional
-        case .ephemeral:
-            self = .ephemeral
-        default:
-            self = .notDetermined
-        }
-    }
-}
-#endif

--- a/Sources/Notification/EmulatedNotificationManager.swift
+++ b/Sources/Notification/EmulatedNotificationManager.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Combine
 import Harness
-import Notification
 
 open class EmulatedNotificationManager: NotificationManager {
     

--- a/Sources/Notification/RemoteNotification.swift
+++ b/Sources/Notification/RemoteNotification.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public protocol RemoteNotification {
     /// Apple Push Service content payload.
     var aps: APS { get }

--- a/Sources/Notification/Traffic.swift
+++ b/Sources/Notification/Traffic.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public enum Traffic {
     case silent(Payload)
     case presented(Payload)

--- a/Sources/Notification/UserNotification+Action.swift
+++ b/Sources/Notification/UserNotification+Action.swift
@@ -30,6 +30,7 @@ public extension UserNotification {
 }
 
 extension UserNotification.Action: CustomStringConvertible {
+    @available(*, deprecated, renamed: "debugDescription")
     public var description: String {
         """
         UserNotification.Action {
@@ -43,32 +44,16 @@ extension UserNotification.Action: CustomStringConvertible {
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UserNotification.Action {
-    static let `default`: Self = .init(id: UNNotificationDefaultActionIdentifier)
-    static let dismiss: Self = .init(id: UNNotificationDismissActionIdentifier)
-}
-
-public extension UNNotificationAction {
-    convenience init(_ action: UserNotification.Action) {
-        var options = UNNotificationActionOptions()
-        if action.authenticationRequired {
-            options.insert(.authenticationRequired)
+extension UserNotification.Action: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Action {
+          id: \(id)
+          title: \(title)
+          authenticationRequired: \(authenticationRequired ? "YES" : "NO")
+          destructive: \(destructive ? "YES" : "NO")
+          foreground: \(foreground ? "YES" : "NO")
         }
-        if action.destructive {
-            options.insert(.destructive)
-        }
-        if action.foreground {
-            options.insert(.foreground)
-        }
-        
-        self.init(
-            identifier: action.id,
-            title: action.title,
-            options: options
-        )
+        """
     }
 }
-#endif

--- a/Sources/Notification/UserNotification+Attachment.swift
+++ b/Sources/Notification/UserNotification+Attachment.swift
@@ -23,20 +23,14 @@ public extension UserNotification {
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UserNotification.Attachment {
-    init(_ attachment: UNNotificationAttachment) {
-        id = attachment.identifier
-        url = attachment.url
-        type = attachment.type
+extension UserNotification.Attachment: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Attachment {
+          id: \(id)
+          url: \(url.absoluteString)
+          type: \(type)
+        }
+        """
     }
 }
-
-public extension UNNotificationAttachment {
-    convenience init(_ attachment: UserNotification.Attachment) throws {
-        try self.init(identifier: attachment.id, url: attachment.url, options: nil)
-    }
-}
-#endif

--- a/Sources/Notification/UserNotification+Category.swift
+++ b/Sources/Notification/UserNotification+Category.swift
@@ -16,17 +16,15 @@ public extension UserNotification {
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UNNotificationCategory {
-    convenience init(_ category: UserNotification.Category) {
-        self.init(
-            identifier: category.id,
-            actions: category.actions.map { UNNotificationAction($0) },
-            intentIdentifiers: [],
-            options: .init()
-        )
+extension UserNotification.Category: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Category {
+          id: \(id)
+          actions: [
+            \(actions.map(\.debugDescription))
+          ]
+        }
+        """
     }
 }
-#endif

--- a/Sources/Notification/UserNotification+Content.swift
+++ b/Sources/Notification/UserNotification+Content.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public extension UserNotification {
     struct Content {
         /// Optional array of attachments.
@@ -53,48 +51,23 @@ public extension UserNotification {
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UNNotificationContent {
-    var content: UserNotification.Content {
-        #if os(macOS)
-        let imageName = ""
-        #else
-        let imageName = launchImageName
-        #endif
-        
-        return UserNotification.Content(
-            attachments: attachments.map { UserNotification.Attachment($0) },
-            badge: badge?.intValue,
-            body: body,
-            categoryId: categoryIdentifier,
-            launchImageName: imageName,
-            sound: nil,
-            subtitle: subtitle,
-            threadIdentifier: threadIdentifier,
-            title: title,
-            payload: userInfo
-        )
+extension UserNotification.Content: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Content {
+          attachments: [
+            \(attachments.map(\.debugDescription))
+          ]
+          badge: \(badge?.description ?? "NIL")
+          body: \(body)
+          categoryId: \(categoryId)
+          launchImageName: \(launchImageName)
+          sound: \(sound?.debugDescription ?? "NIL")
+          subtitle: \(subtitle)
+          threadIdentifier: \(threadIdentifier)
+          title: \(title)
+          payload: \(payload.debugDescription)
+        }
+        """
     }
 }
-
-public extension UserNotification.Content {
-    init(_ content: UNNotificationContent) {
-        attachments = content.attachments.map { UserNotification.Attachment($0) }
-        badge = content.badge?.intValue
-        body = content.body
-        categoryId = content.categoryIdentifier
-        #if os(macOS)
-        launchImageName = ""
-        #else
-        launchImageName = content.launchImageName
-        #endif
-        sound = nil
-        subtitle = content.subtitle
-        threadIdentifier = content.threadIdentifier
-        title = content.title
-        payload = content.userInfo
-    }
-}
-#endif

--- a/Sources/Notification/UserNotification+Request.swift
+++ b/Sources/Notification/UserNotification+Request.swift
@@ -18,48 +18,14 @@ public extension UserNotification {
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UserNotification.Request {
-    init(_ request: UNNotificationRequest) {
-        id = request.identifier
-        content = request.content.content
-        trigger = request.trigger?.trigger
-    }
-}
-
-public extension UserNotification.Request {
-    var unNotificationRequest: UNNotificationRequest {
-        let notificationContent = UNMutableNotificationContent()
-        notificationContent.attachments = content.attachments.compactMap { try? UNNotificationAttachment($0) }
-        notificationContent.badge = content.badge != nil ? NSNumber(value: content.badge!) : nil
-        notificationContent.body = content.body
-        notificationContent.categoryIdentifier = content.categoryId
-        #if !os(macOS)
-        notificationContent.launchImageName = content.launchImageName
-        #endif
-        notificationContent.sound = content.sound?.unNotificationSound
-        notificationContent.subtitle = content.subtitle
-        notificationContent.threadIdentifier = content.threadIdentifier
-        notificationContent.title = content.title
-        notificationContent.userInfo = content.payload
-        
-        let notificationTrigger: UNNotificationTrigger?
-        switch trigger?.event {
-        case .calendar(let components):
-            notificationTrigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: trigger!.repeats)
-        case .timeInterval(let interval):
-            // 'NSInternalInconsistencyException', reason: 'time interval must be greater than 0'
-            let timeInterval = max(interval, 0.1)
-            notificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: trigger!.repeats)
-        case .convertible(let convertible):
-            notificationTrigger = convertible.unNotificationTrigger
-        default:
-            notificationTrigger = nil
+extension UserNotification.Request: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Request {
+          id: \(id)
+          content: \(content.debugDescription)
+          trigger: \(trigger?.debugDescription ?? "NIL")
         }
-        
-        return UNNotificationRequest(identifier: id, content: notificationContent, trigger: notificationTrigger)
+        """
     }
 }
-#endif

--- a/Sources/Notification/UserNotification+Sound.swift
+++ b/Sources/Notification/UserNotification+Sound.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public extension UserNotification {
     enum Sound {
         /// Default alerts
@@ -14,28 +12,46 @@ public extension UserNotification {
         ///   - name: The name of a sound file to be played for a critical alert. (Contained in the app bundle)
         ///   - volume: The audio volume is expected to be between 0.0f and 1.0f.
         case critical(name: String? = nil, volume: Float? = nil)
-    }
-}
-
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UserNotification.Sound {
-    var unNotificationSound: UNNotificationSound {
-        switch self {
-        case .named(let name):
-            return .init(named: .init(rawValue: name))
-        case .critical(let name, let volume) where name != nil && volume != nil:
-            return .criticalSoundNamed(.init(rawValue: name!), withAudioVolume: volume!)
-        case .critical(let name, let volume) where name != nil && volume == nil:
-            return .criticalSoundNamed(.init(rawValue: name!))
-        case .critical(let name, let volume) where name == nil && volume != nil:
-            return .defaultCriticalSound(withAudioVolume: volume!)
-        case .critical(let name, let volume) where name == nil && volume == nil:
-            return .defaultCritical
-        default:
-            return .default
+        
+        public var isDefault: Bool {
+            switch self {
+            case .default:
+                return true
+            default:
+                return false
+            }
+        }
+        
+        public var isCritical: Bool {
+            switch self {
+            case .critical:
+                return true
+            default:
+                return false
+            }
+        }
+        
+        public var name: String? {
+            switch self {
+            case .named(let name):
+                return name
+            case .critical(let name, _):
+                return name
+            default:
+                return nil
+            }
         }
     }
 }
-#endif
+
+extension UserNotification.Sound: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Sound {
+          name: \(name ?? "NIL")
+          isDefault: \(isDefault ? "YES" : "NO")
+          isCritical: \(isCritical ? "YES" : "NO")
+        }
+        """
+    }
+}

--- a/Sources/Notification/UserNotification+Trigger.swift
+++ b/Sources/Notification/UserNotification+Trigger.swift
@@ -2,10 +2,12 @@ import Foundation
 #if canImport(UserNotifications)
 import UserNotifications
 
+@available(*, deprecated)
 public protocol NotificationTriggerConvertible {
     var unNotificationTrigger: UNNotificationTrigger { get }
 }
 
+@available(*, deprecated)
 public struct AnyNotificationTriggerConvertible: NotificationTriggerConvertible {
     public let unNotificationTrigger: UNNotificationTrigger
     
@@ -23,6 +25,7 @@ public extension UserNotification {
             case timeInterval(TimeInterval)
             case calendar(DateComponents)
             #if canImport(UserNotifications)
+            @available(*, deprecated)
             case convertible(NotificationTriggerConvertible)
             #endif
         }
@@ -40,25 +43,30 @@ public extension UserNotification {
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
+extension UserNotification.Trigger: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification.Trigger {
+          event: \(event?.debugDescription ?? "NIL")
+          repeats: \(repeats ? "YES" : "NO")
+        }
+        """
+    }
+}
 
-public extension UNNotificationTrigger {
-    var trigger: UserNotification.Trigger {
+extension UserNotification.Trigger.Event: CustomDebugStringConvertible {
+    public var debugDescription: String {
         switch self {
-        #if !os(macOS)
-        case let value as UNLocationNotificationTrigger:
-            return UserNotification.Trigger(event: .convertible(AnyNotificationTriggerConvertible(value)), repeats: value.repeats)
+        case .push:
+            return "UserNotification.Trigger.Event { Push }"
+        case .timeInterval(let timeInterval):
+            return "UserNotification.Trigger.Event { Time Interval - \(timeInterval) }"
+        case .calendar(let dateComponents):
+            return "UserNotification.Trigger.Event { Date Components - \(dateComponents) }"
+        #if canImport(UserNotifications)
+        case .convertible(_):
+            return "UserNotification.Trigger.Event { <DEPRECATED> }"
         #endif
-        case let value as UNCalendarNotificationTrigger:
-            return UserNotification.Trigger(event: .calendar(value.dateComponents), repeats: value.repeats)
-        case let value as UNTimeIntervalNotificationTrigger:
-            return UserNotification.Trigger(event: .timeInterval(value.timeInterval), repeats: value.repeats)
-        case let value as UNPushNotificationTrigger:
-            return UserNotification.Trigger(event: .push, repeats: value.repeats)
-        default:
-            return UserNotification.Trigger(repeats: repeats)
         }
     }
 }
-#endif

--- a/Sources/Notification/UserNotification.swift
+++ b/Sources/Notification/UserNotification.swift
@@ -6,20 +6,20 @@ public struct UserNotification {
     
     public init(
         date: Date = Date(),
-        request: Request = .init()
+        request: Request = Request()
     ) {
         self.date = date
         self.request = request
     }
 }
 
-#if canImport(UserNotifications)
-import UserNotifications
-
-public extension UserNotification {
-    init(_ notification: UNNotification) {
-        date = notification.date
-        request = .init()
+extension UserNotification: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        """
+        UserNotification {
+          date: \(date.debugDescription)
+          request: \(request.debugDescription)
+        }
+        """
     }
 }
-#endif

--- a/Sources/Notification/UserNotifications/UNAuthorizationStatus+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNAuthorizationStatus+Notification.swift
@@ -1,0 +1,59 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension AuthorizationStatus {
+    @available(*, deprecated, renamed: "AuthorizationStatus.make(with:)")
+    init(authorizationStatus: UNAuthorizationStatus) {
+        switch authorizationStatus {
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        case .provisional:
+            self = .provisional
+        case .ephemeral:
+            self = .ephemeral
+        default:
+            self = .notDetermined
+        }
+    }
+    
+    static func make(with authorizationStatus: UNAuthorizationStatus) -> AuthorizationStatus {
+        switch authorizationStatus {
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .authorized:
+            return .authorized
+        case .provisional:
+            return .provisional
+        case .ephemeral:
+            return .ephemeral
+        @unknown default:
+            return .notDetermined
+        }
+    }
+}
+
+public extension UNAuthorizationStatus {
+    static func make(with authorizationStatus: AuthorizationStatus) -> UNAuthorizationStatus {
+        switch authorizationStatus {
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .authorized:
+            return .authorized
+        case .provisional:
+            return .provisional
+        case .ephemeral:
+            #if os(iOS)
+            return .ephemeral
+            #else
+            return .notDetermined
+            #endif
+        }
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotification+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotification+Notification.swift
@@ -1,0 +1,18 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification {
+    static func make(with notification: UNNotification) -> UserNotification {
+        UserNotification(
+            date: notification.date,
+            request: UserNotification.Request.make(with: notification.request)
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.make(with:)")
+    init(_ notification: UNNotification) {
+        date = notification.date
+        request = .init()
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationAction+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationAction+Notification.swift
@@ -1,0 +1,70 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Action {
+    static let `default` = UserNotification.Action(id: UNNotificationDefaultActionIdentifier)
+    static let dismiss = UserNotification.Action(id: UNNotificationDismissActionIdentifier)
+    
+    static func make(with action: UNNotificationAction) -> UserNotification.Action {
+        UserNotification.Action(
+            id: action.identifier,
+            title: action.title,
+            authenticationRequired: action.options.contains(.authenticationRequired),
+            destructive: action.options.contains(.destructive),
+            foreground: action.options.contains(.foreground)
+        )
+    }
+}
+
+public extension UNNotificationAction {
+    static func make(with action: UserNotification.Action) -> UNNotificationAction {
+        var options = UNNotificationActionOptions()
+        if action.authenticationRequired {
+            options.insert(.authenticationRequired)
+        }
+        if action.destructive {
+            options.insert(.destructive)
+        }
+        if action.foreground {
+            options.insert(.foreground)
+        }
+        
+        return UNNotificationAction(
+            identifier: action.id,
+            title: action.title,
+            options: options
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UNNotificationAction.make(with:)")
+    convenience init(_ action: UserNotification.Action) {
+        var options = UNNotificationActionOptions()
+        if action.authenticationRequired {
+            options.insert(.authenticationRequired)
+        }
+        if action.destructive {
+            options.insert(.destructive)
+        }
+        if action.foreground {
+            options.insert(.foreground)
+        }
+        
+        self.init(
+            identifier: action.id,
+            title: action.title,
+            options: options
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Action.make(with:)")
+    var notificationUserNotificationAction: UserNotification.Action {
+        UserNotification.Action(
+            id: identifier,
+            title: title,
+            authenticationRequired: options.contains(.authenticationRequired),
+            destructive: options.contains(.destructive),
+            foreground: options.contains(.foreground)
+        )
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationAttachment+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationAttachment+Notification.swift
@@ -1,0 +1,48 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Attachment {
+    static func make(with attachment: UNNotificationAttachment) -> UserNotification.Attachment {
+        UserNotification.Attachment(
+            id: attachment.identifier,
+            url: attachment.url,
+            type: attachment.type
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Attachment.make(with:)")
+    init(_ attachment: UNNotificationAttachment) {
+        id = attachment.identifier
+        url = attachment.url
+        type = attachment.type
+    }
+}
+
+public extension UNNotificationAttachment {
+    static func make(with attachment: UserNotification.Attachment) throws -> UNNotificationAttachment {
+        try UNNotificationAttachment(
+            identifier: attachment.id,
+            url: attachment.url,
+            options: nil
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UNNotificationAttachment.make(with:)")
+    convenience init(_ attachment: UserNotification.Attachment) throws {
+        try self.init(
+            identifier: attachment.id,
+            url: attachment.url,
+            options: nil
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Attachment.make(with:)")
+    var notificationUserNotificationAttachment: UserNotification.Attachment {
+        UserNotification.Attachment(
+            id: identifier,
+            url: url,
+            type: type
+        )
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationCategory+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationCategory+Notification.swift
@@ -1,0 +1,41 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Category {
+    static func make(with category: UNNotificationCategory) -> UserNotification.Category {
+        UserNotification.Category(
+            id: category.identifier,
+            actions: category.actions.map { UserNotification.Action.make(with: $0) }
+        )
+    }
+}
+
+public extension UNNotificationCategory {
+    static func make(with category: UserNotification.Category) -> UNNotificationCategory {
+        UNNotificationCategory(
+            identifier: category.id,
+            actions: category.actions.map { UNNotificationAction.make(with: $0) },
+            intentIdentifiers: [],
+            options: .init()
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UNNotificationCategory.make(with:)")
+    convenience init(_ category: UserNotification.Category) {
+        self.init(
+            identifier: category.id,
+            actions: category.actions.map { UNNotificationAction($0) },
+            intentIdentifiers: [],
+            options: .init()
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Category.make(with:)")
+    var notificationUserNotificationCategory: UserNotification.Category {
+        UserNotification.Category(
+            id: identifier,
+            actions: actions.map { $0.notificationUserNotificationAction }
+        )
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationContent+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationContent+Notification.swift
@@ -1,0 +1,87 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Content {
+    static func make(with notificationContent: UNNotificationContent) -> UserNotification.Content {
+        #if os(iOS)
+        let launchImageName = notificationContent.launchImageName
+        #else
+        let launchImageName = ""
+        #endif
+        
+        return UserNotification.Content(
+            attachments: notificationContent.attachments.map { UserNotification.Attachment.make(with: $0) },
+            badge: notificationContent.badge?.intValue,
+            body: notificationContent.body,
+            categoryId: notificationContent.categoryIdentifier,
+            launchImageName: launchImageName,
+            sound: nil,
+            subtitle: notificationContent.subtitle,
+            threadIdentifier: notificationContent.threadIdentifier,
+            title: notificationContent.title,
+            payload: notificationContent.userInfo
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Content.make(with:)")
+    init(_ content: UNNotificationContent) {
+        attachments = content.attachments.map { $0.notificationUserNotificationAttachment }
+        badge = content.badge?.intValue
+        body = content.body
+        categoryId = content.categoryIdentifier
+        #if os(iOS)
+        launchImageName = content.launchImageName
+        #else
+        launchImageName = ""
+        #endif
+        sound = nil
+        subtitle = content.subtitle
+        threadIdentifier = content.threadIdentifier
+        title = content.title
+        payload = content.userInfo
+    }
+}
+
+public extension UNNotificationContent {
+    static func make(with notificationContent: UserNotification.Content) -> UNNotificationContent {
+        let content = UNMutableNotificationContent()
+        content.attachments = notificationContent.attachments.compactMap { try? UNNotificationAttachment.make(with: $0) }
+        content.badge = notificationContent.badge as NSNumber?
+        content.body = notificationContent.body
+        content.categoryIdentifier = notificationContent.categoryId
+        #if os(iOS)
+        content.launchImageName = notificationContent.launchImageName
+        #endif
+        if let sound = notificationContent.sound {
+            content.sound = UNNotificationSound.make(with: sound)
+        }
+        content.subtitle = notificationContent.subtitle
+        content.threadIdentifier = notificationContent.threadIdentifier
+        content.title = notificationContent.title
+        content.userInfo = notificationContent.payload
+        return content
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Content.make(with:)")
+    var content: UserNotification.Content {
+        #if os(macOS)
+        let imageName = ""
+        #else
+        let imageName = launchImageName
+        #endif
+        
+        return UserNotification.Content(
+            attachments: attachments.map { $0.notificationUserNotificationAttachment },
+            badge: badge?.intValue,
+            body: body,
+            categoryId: categoryIdentifier,
+            launchImageName: imageName,
+            sound: nil,
+            subtitle: subtitle,
+            threadIdentifier: threadIdentifier,
+            title: title,
+            payload: userInfo
+        )
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationRequest+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationRequest+Notification.swift
@@ -1,0 +1,77 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Request {
+    static func make(with request: UNNotificationRequest) -> UserNotification.Request {
+        UserNotification.Request(
+            id: request.identifier,
+            content: UserNotification.Content.make(with: request.content),
+            trigger: request.trigger.map { UserNotification.Trigger.make(with: $0) }
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Request.make(with:)")
+    init(_ request: UNNotificationRequest) {
+        id = request.identifier
+        content = request.content.content
+        trigger = request.trigger?.trigger
+    }
+    
+    @available(*, deprecated, renamed: "UNNotificationRequest.make(with:)")
+    var unNotificationRequest: UNNotificationRequest {
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.attachments = content.attachments.compactMap { try? UNNotificationAttachment($0) }
+        notificationContent.badge = content.badge != nil ? NSNumber(value: content.badge!) : nil
+        notificationContent.body = content.body
+        notificationContent.categoryIdentifier = content.categoryId
+        #if !os(macOS)
+        notificationContent.launchImageName = content.launchImageName
+        #endif
+        notificationContent.sound = content.sound?.unNotificationSound
+        notificationContent.subtitle = content.subtitle
+        notificationContent.threadIdentifier = content.threadIdentifier
+        notificationContent.title = content.title
+        notificationContent.userInfo = content.payload
+        
+        let notificationTrigger: UNNotificationTrigger?
+        switch trigger?.event {
+        case .calendar(let components):
+            notificationTrigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: trigger!.repeats)
+        case .timeInterval(let interval):
+            // 'NSInternalInconsistencyException', reason: 'time interval must be greater than 0'
+            let timeInterval = max(interval, 0.1)
+            notificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: trigger!.repeats)
+        case .convertible(let convertible):
+            notificationTrigger = convertible.unNotificationTrigger
+        default:
+            notificationTrigger = nil
+        }
+        
+        return UNNotificationRequest(identifier: id, content: notificationContent, trigger: notificationTrigger)
+    }
+}
+
+public extension UNNotificationRequest {
+    static func make(with request: UserNotification.Request) -> UNNotificationRequest {
+        var trigger: UNNotificationTrigger?
+        if let requestTrigger = request.trigger {
+            trigger = try? UNNotificationTrigger.make(with: requestTrigger)
+        }
+        
+        return UNNotificationRequest(
+            identifier: request.id,
+            content: UNNotificationContent.make(with: request.content),
+            trigger: trigger
+        )
+    }
+    
+    @available(*, deprecated, renamed: "UNNotificationRequest.make(with:)")
+    convenience init(_ request: UserNotification.Request) {
+        self.init(
+            identifier: request.id,
+            content: UNNotificationContent.make(with: request.content),
+            trigger: nil
+        )
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationSound+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationSound+Notification.swift
@@ -1,0 +1,42 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Sound {
+    @available(*, deprecated, renamed: "UNNotificationSound.make(with:)")
+    var unNotificationSound: UNNotificationSound {
+        switch self {
+        case .named(let name):
+            return .init(named: .init(rawValue: name))
+        case .critical(let name, let volume) where name != nil && volume != nil:
+            return .criticalSoundNamed(.init(rawValue: name!), withAudioVolume: volume!)
+        case .critical(let name, let volume) where name != nil && volume == nil:
+            return .criticalSoundNamed(.init(rawValue: name!))
+        case .critical(let name, let volume) where name == nil && volume != nil:
+            return .defaultCriticalSound(withAudioVolume: volume!)
+        case .critical(let name, let volume) where name == nil && volume == nil:
+            return .defaultCritical
+        default:
+            return .default
+        }
+    }
+}
+
+public extension UNNotificationSound {
+    static func make(with notificationSound: UserNotification.Sound) -> UNNotificationSound {
+        switch notificationSound {
+        case .critical(.some(let name), .some(let volume)):
+            return .criticalSoundNamed(UNNotificationSoundName(name), withAudioVolume: volume)
+        case .critical(.some(let name), .none):
+            return .criticalSoundNamed(UNNotificationSoundName(name))
+        case .critical(.none, .some(let volume)):
+            return .defaultCriticalSound(withAudioVolume: volume)
+        case .critical(.none, .none):
+            return .defaultCritical
+        case .named(let name):
+            return .init(named: UNNotificationSoundName(name))
+        default:
+            return .default
+        }
+    }
+}
+#endif

--- a/Sources/Notification/UserNotifications/UNNotificationTrigger+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationTrigger+Notification.swift
@@ -1,0 +1,63 @@
+#if canImport(UserNotifications)
+import UserNotifications
+
+public extension UserNotification.Trigger {
+    static func make(with trigger: UNNotificationTrigger) -> UserNotification.Trigger {
+        switch trigger {
+        case is UNPushNotificationTrigger:
+            return UserNotification.Trigger(
+                event: .push,
+                repeats: trigger.repeats
+            )
+        case let interval as UNTimeIntervalNotificationTrigger:
+            return UserNotification.Trigger(
+                event: .timeInterval(interval.timeInterval),
+                repeats: trigger.repeats
+            )
+        case let calendar as UNCalendarNotificationTrigger:
+            return UserNotification.Trigger(
+                event: .calendar(calendar.dateComponents),
+                repeats: trigger.repeats
+            )
+        default:
+            return UserNotification.Trigger(
+                event: nil,
+                repeats: trigger.repeats
+            )
+        }
+    }
+}
+
+public extension UNNotificationTrigger {
+    static func make(with trigger: UserNotification.Trigger) throws -> UNNotificationTrigger {
+        switch trigger.event {
+        case .timeInterval(let timeInterval):
+            return UNTimeIntervalNotificationTrigger(
+                timeInterval: timeInterval,
+                repeats: trigger.repeats
+            )
+        case .calendar(let dateComponents):
+            return UNCalendarNotificationTrigger(
+                dateMatching: dateComponents,
+                repeats: trigger.repeats
+            )
+        default:
+            throw CocoaError(.featureUnsupported)
+        }
+    }
+    
+    @available(*, deprecated, renamed: "UserNotification.Trigger.make(with:)")
+    var trigger: UserNotification.Trigger {
+        switch self {
+        case let value as UNCalendarNotificationTrigger:
+            return UserNotification.Trigger(event: .calendar(value.dateComponents), repeats: value.repeats)
+        case let value as UNTimeIntervalNotificationTrigger:
+            return UserNotification.Trigger(event: .timeInterval(value.timeInterval), repeats: value.repeats)
+        case let value as UNPushNotificationTrigger:
+            return UserNotification.Trigger(event: .push, repeats: value.repeats)
+        default:
+            return UserNotification.Trigger(repeats: repeats)
+        }
+    }
+}
+#endif

--- a/Tests/NotificationTests/NotificationManagerTests.swift
+++ b/Tests/NotificationTests/NotificationManagerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import Combine
 @testable import Notification
-import NotificationEmulation
 
 final class NotificationManagerTests: XCTestCase {
     


### PR DESCRIPTION
The `UNNotification` extensions were a bit inconsistent. Some provider mapping through variables and others through convenience initializers. This converts all of those usages to static functions using the `make(with:)` signature.

Also
* Removed the `NotificationEmulation` target (moved the class to the full package).
* Added dependency on `AsyncPlus` in preparation for swift-concurrency expansion.