### PR TITLE
Simplified Traffic

### DIFF
--- a/Sources/Notification/AbstractNotificationManager.swift
+++ b/Sources/Notification/AbstractNotificationManager.swift
@@ -60,7 +60,7 @@ open class AbstractNotificationManager: NSObject, NotificationManager {
         let metadata: Logger.Metadata = [
             "apnsToken": .string(content.json(redacting: redactions))
         ]
-        logger.debug("Registered for Remote Notifications", metadata: metadata)
+        logger.debug("Remote Notification Registration Complete", metadata: metadata)
         yieldAPNSTokenData(token)
     }
     
@@ -68,15 +68,15 @@ open class AbstractNotificationManager: NSObject, NotificationManager {
         let metadata: Logger.Metadata = [
             "localizedDescription": .string(error.localizedDescription)
         ]
-        logger.error("Remote Register Failed", metadata: metadata)
+        logger.error("Remote Notification Registration Failed", metadata: metadata)
     }
     
-    public func didReceiveRemoteNotification(_ payload: Payload) async throws -> Bool {
+    public func didReceiveRemoteNotification(_ payload: Payload, inBackground: Bool) async throws -> Bool {
         let metadata: Logger.Metadata = [
             "payload": .string(payload.json(redacting: redactions))
         ]
-        logger.debug("Received Remote Notification", metadata: metadata)
-        yieldTraffic(.silent(payload))
+        logger.debug("Notification Received (\(inBackground ? "Background" : "Foreground")", metadata: metadata)
+        yieldTraffic(.received(payload: payload, inBackground: inBackground))
         return true
     }
     

--- a/Sources/Notification/EmulatedNotificationManager.swift
+++ b/Sources/Notification/EmulatedNotificationManager.swift
@@ -62,14 +62,7 @@ open class EmulatedNotificationManager: AbstractNotificationManager {
     }
     
     public override func localNotificationRequest(_ request: UserNotification.Request) throws {
-        let traffic: Traffic
-        if request.content.payload.aps?.isSilent == true {
-            traffic = .silent(request.content.payload)
-        } else {
-            traffic = .interacted(request.content.payload, .default)
-        }
-        
-        yieldTraffic(traffic)
+        yieldTraffic(.received(payload: request.content.payload, inBackground: false))
     }
     
     public override func removePendingAndDeliveredNotifications(withId id: String) {

--- a/Sources/Notification/Traffic.swift
+++ b/Sources/Notification/Traffic.swift
@@ -1,5 +1,28 @@
 public enum Traffic {
-    case silent(Payload)
-    case presented(Payload)
-    case interacted(Payload, UserNotification.Action)
+    case interaction(payload: Payload, action: UserNotification.Action)
+    case received(payload: Payload, inBackground: Bool)
+    
+    public var payload: Payload {
+        switch self {
+        case .interaction(let payload, _), .received(let payload, _):
+            return payload
+        }
+    }
+}
+
+public extension Traffic {
+    @available(*, deprecated, renamed: "received(payload:inBackground:)")
+    static func silent(_ payload: Payload) -> Traffic {
+        received(payload: payload, inBackground: true)
+    }
+    
+    @available(*, deprecated, renamed: "received(payload:inBackground:)")
+    static func presented(_ payload: Payload) -> Traffic {
+        received(payload: payload, inBackground: false)
+    }
+    
+    @available(*, deprecated, renamed: "interaction(payload:action:)")
+    static func interacted(_ payload: Payload, _ action: UserNotification.Action) -> Traffic {
+        interaction(payload: payload, action: action)
+    }
 }

--- a/Sources/Notification/UserNotifications/UserNotificationManager.swift
+++ b/Sources/Notification/UserNotifications/UserNotificationManager.swift
@@ -81,8 +81,8 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
         let metadata: Logger.Metadata = [
             "payload": .string(payload.json(redacting: redactions))
         ]
-        logger.debug("Presenting Notification", metadata: metadata)
-        yieldTraffic(.presented(payload))
+        logger.debug("Notification Received (Foreground)", metadata: metadata)
+        yieldTraffic(.received(payload: payload, inBackground: false))
         
         DispatchQueue.main.async {
             completionHandler(UNNotificationPresentationOptions([.list, .banner, .sound, .badge]))
@@ -105,8 +105,8 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
         let metadata: Logger.Metadata = [
             "payload": .string(payload.json(redacting: redactions))
         ]
-        logger.debug("Interacted With Notification", metadata: metadata)
-        yieldTraffic(.interacted(payload, action))
+        logger.debug("Notification Interaction", metadata: metadata)
+        yieldTraffic(.interaction(payload: payload, action: action))
         
         DispatchQueue.main.async {
             completionHandler()


### PR DESCRIPTION
Determining 'silent' notifications wasn't being handled correctly. The `Traffic` enumeration has been revised to remove the silent option and instead require knowledge of the application state (foreground/background).