### PR TITLE
Hashable/Sendable Payload

### DIFF
--- a/Sources/Notification/APNS/APS.swift
+++ b/Sources/Notification/APNS/APS.swift
@@ -51,6 +51,11 @@ public struct APS: Hashable, Sendable {
         self.category = category
         self.threadId = threadId
     }
+
+    public init(dictionary: [String: Any]) throws {
+        let data = try JSONSerialization.data(withJSONObject: dictionary)
+        self = try JSONDecoder().decode(Self.self, from: data)
+    }
 }
 
 extension APS: Codable {
@@ -86,7 +91,12 @@ extension APS: Codable {
 }
 
 public extension APS {
+    @available(*, deprecated, renamed: "userInfo")
     var payload: Payload? {
+        userInfo
+    }
+
+    var userInfo: UserInfo? {
         guard let data = try? JSONEncoder().encode(self) else {
             return nil
         }
@@ -102,7 +112,8 @@ public extension APS {
     var isSilent: Bool { contentAvailable == 1 }
 }
 
-public extension Payload {
+public extension UserInfo {
+    @available(*, deprecated)
     var aps: APS? {
         guard let dictionary = self["aps"] else {
             return nil

--- a/Sources/Notification/AbstractNotificationManager.swift
+++ b/Sources/Notification/AbstractNotificationManager.swift
@@ -56,9 +56,9 @@ open class AbstractNotificationManager: NSObject, NotificationManager {
 
     public func didRegisterForRemoteNotificationsWithDeviceToken(_ token: Data) {
         let hex = token.map { String(format: "%.2hhx", $0) }.joined()
-        let content: [AnyHashable: Any] = ["hex": hex]
+        let content: Logger.Metadata = ["hex": .string(hex)]
         let metadata: Logger.Metadata = [
-            "apnsToken": .string(content.json(redacting: redactions)),
+            "apnsToken": .dictionary(content.redacting(keyPaths: redactions)),
         ]
         logger.debug("Registered for Remote Notifications", metadata: metadata)
         yieldAPNSTokenData(token)
@@ -72,11 +72,12 @@ open class AbstractNotificationManager: NSObject, NotificationManager {
     }
 
     public func didReceiveRemoteNotification(_ userInfo: UserInfo) async throws -> Bool {
+        let payload = try UserNotification.Payload(userInfo: userInfo)
         let metadata: Logger.Metadata = [
-            "payload": .string(userInfo.json(redacting: redactions)),
+            "payload": .dictionary(payload.metadata.redacting(keyPaths: redactions)),
         ]
         logger.debug("Received Remote Notification", metadata: metadata)
-        yieldTraffic(.silent(userInfo))
+        yieldTraffic(.silent(payload))
         return true
     }
 

--- a/Sources/Notification/AbstractNotificationManager.swift
+++ b/Sources/Notification/AbstractNotificationManager.swift
@@ -71,12 +71,12 @@ open class AbstractNotificationManager: NSObject, NotificationManager {
         logger.error("Remote Register Failed", metadata: metadata)
     }
 
-    public func didReceiveRemoteNotification(_ payload: Payload) async throws -> Bool {
+    public func didReceiveRemoteNotification(_ userInfo: UserInfo) async throws -> Bool {
         let metadata: Logger.Metadata = [
-            "payload": .string(payload.json(redacting: redactions)),
+            "payload": .string(userInfo.json(redacting: redactions)),
         ]
         logger.debug("Received Remote Notification", metadata: metadata)
-        yieldTraffic(.silent(payload))
+        yieldTraffic(.silent(userInfo))
         return true
     }
 

--- a/Sources/Notification/EmulatedNotificationManager.swift
+++ b/Sources/Notification/EmulatedNotificationManager.swift
@@ -62,13 +62,13 @@ open class EmulatedNotificationManager: AbstractNotificationManager {
     }
 
     override public func localNotificationRequest(_ request: UserNotification.Request) throws {
-        let traffic: Traffic = if request.content.payload.aps?.isSilent == true {
-            .silent(request.content.payload)
+        let traffic: Traffic = if request.content.aps?.isSilent == true {
+            .silent(request.content.userInfo)
         } else {
             #if os(tvOS)
-            .interacted(request.content.payload, ())
+            .interacted(request.content.userInfo, ())
             #else
-            .interacted(request.content.payload, .default)
+            .interacted(request.content.userInfo, .default)
             #endif
         }
 

--- a/Sources/Notification/EmulatedNotificationManager.swift
+++ b/Sources/Notification/EmulatedNotificationManager.swift
@@ -62,13 +62,16 @@ open class EmulatedNotificationManager: AbstractNotificationManager {
     }
 
     override public func localNotificationRequest(_ request: UserNotification.Request) throws {
+        let userInfo = request.content.userInfo
+        let payload = try UserNotification.Payload(userInfo: userInfo)
+
         let traffic: Traffic = if request.content.aps?.isSilent == true {
-            .silent(request.content.userInfo)
+            .silent(payload)
         } else {
             #if os(tvOS)
-            .interacted(request.content.userInfo, ())
+            .interacted(payload)
             #else
-            .interacted(request.content.userInfo, .default)
+            .interacted(payload, .default)
             #endif
         }
 

--- a/Sources/Notification/Extensions/Logger.Metadata+Notification.swift
+++ b/Sources/Notification/Extensions/Logger.Metadata+Notification.swift
@@ -1,0 +1,34 @@
+import Logging
+
+extension Logger.Metadata {
+    func redacting(keyPaths: [String] = [], with redaction: String = "<REDACTED>") -> Self {
+        var dictionary = self
+
+        for keyPath in keyPaths {
+            // Extract the key for this level
+            let split = keyPath.split(separator: ".", maxSplits: 1)
+            let key = String(split[0])
+
+            guard var value = dictionary[key] else {
+                continue
+            }
+
+            if split.count > 1 {
+                // Continue down the path
+                let subPath = String(split[1])
+                guard case .dictionary(let metadata) = value else {
+                    continue
+                }
+
+                let redacted = metadata.redacting(keyPaths: [subPath], with: redaction)
+                value = .dictionary(redacted)
+            } else {
+                value = .string(redaction)
+            }
+
+            dictionary[key] = value
+        }
+
+        return dictionary
+    }
+}

--- a/Sources/Notification/Firebase/FCMOptions.swift
+++ b/Sources/Notification/Firebase/FCMOptions.swift
@@ -7,10 +7,7 @@ public struct FCMOptions: Hashable, Sendable, Codable {
         self.image = image
     }
 
-    @available(*, deprecated, renamed: "payload")
-    var notificationContent: Payload { payload }
-
-    var payload: Payload {
+    var userInfo: UserInfo {
         if let image {
             [
                 "fcm_options": [

--- a/Sources/Notification/Firebase/FMCNotification.swift
+++ b/Sources/Notification/Firebase/FMCNotification.swift
@@ -3,8 +3,13 @@ public protocol FCMNotification: RemoteNotification {
 }
 
 public extension FCMNotification {
+    @available(*, deprecated, renamed: "userInfo")
     var payload: Payload {
-        switch (aps.payload, options?.payload) {
+        userInfo
+    }
+
+    var userInfo: UserInfo {
+        switch (aps.userInfo, options?.userInfo) {
         case (.some(let apsPayload), .some(let optionsPayload)):
             apsPayload.merging(optionsPayload) { _, rhs in
                 rhs

--- a/Sources/Notification/Firebase/FirebaseCloudMessage.swift
+++ b/Sources/Notification/Firebase/FirebaseCloudMessage.swift
@@ -20,7 +20,7 @@ open class FirebaseCloudMessage: RemoteNotification, Codable {
         self.options = options
     }
 
-    open var payload: Payload {
+    open var userInfo: UserInfo {
         var content = Payload()
 
         if let notificationContent = aps.payload {
@@ -29,7 +29,7 @@ open class FirebaseCloudMessage: RemoteNotification, Codable {
             }
         }
         if let options {
-            content.merge(options.payload) { _, overwrite in
+            content.merge(options.userInfo) { _, overwrite in
                 overwrite
             }
         }

--- a/Sources/Notification/NotificationManager.swift
+++ b/Sources/Notification/NotificationManager.swift
@@ -94,7 +94,7 @@ public extension NotificationManager {
                 switch value {
                 case .silent(let payload), .interacted(let payload, _):
                     do {
-                        let data = try JSONSerialization.data(withJSONObject: payload)
+                        let data = try JSONSerialization.data(withJSONObject: payload.userInfo)
                         let notification = try decoder.decode(T.self, from: data)
                         stream.continuation.yield(notification)
                     } catch {}
@@ -119,14 +119,14 @@ public extension NotificationManager {
             .compactMap { traffic in
                 switch traffic {
                 case .silent(let payload), .interacted(let payload, _):
-                    payload
+                    payload.userInfo
                 default:
                     nil
                 }
             }
-            // Decode `Payload` to `T`
-            .flatMap { payload in
-                Just(payload)
+            // Decode `UserInfo` to `T`
+            .flatMap { userInfo in
+                Just(userInfo)
                     .tryMap {
                         try JSONSerialization.data(withJSONObject: $0)
                     }

--- a/Sources/Notification/NotificationManager.swift
+++ b/Sources/Notification/NotificationManager.swift
@@ -91,16 +91,28 @@ public extension NotificationManager {
 
         let task = Task {
             for await value in trafficStream() {
+                var notificationPayload: UserNotification.Payload
+                #if os(tvOS)
+                switch value {
+                case .silent(let payload), .interacted(let payload):
+                    notificationPayload = payload
+                default:
+                    continue
+                }
+                #else
                 switch value {
                 case .silent(let payload), .interacted(let payload, _):
-                    do {
-                        let data = try JSONSerialization.data(withJSONObject: payload.userInfo)
-                        let notification = try decoder.decode(T.self, from: data)
-                        stream.continuation.yield(notification)
-                    } catch {}
+                    notificationPayload = payload
                 default:
-                    break
+                    continue
                 }
+                #endif
+
+                do {
+                    let data = try JSONSerialization.data(withJSONObject: notificationPayload.userInfo)
+                    let notification = try decoder.decode(T.self, from: data)
+                    stream.continuation.yield(notification)
+                } catch {}
             }
         }
 
@@ -117,12 +129,21 @@ public extension NotificationManager {
         trafficPublisher
             // `Payload` from '.silent' and '.interacted' only.
             .compactMap { traffic in
+                #if os(tvOS)
+                switch traffic {
+                case .silent(let payload), .interacted(let payload):
+                    payload.userInfo
+                default:
+                    nil
+                }
+                #else
                 switch traffic {
                 case .silent(let payload), .interacted(let payload, _):
                     payload.userInfo
                 default:
                     nil
                 }
+                #endif
             }
             // Decode `UserInfo` to `T`
             .flatMap { userInfo in

--- a/Sources/Notification/NotificationManager.swift
+++ b/Sources/Notification/NotificationManager.swift
@@ -35,7 +35,7 @@ public protocol NotificationManager {
     /// will be interpreted as a `UIBackgroundFetchResult`.
     ///
     /// This can also be called at any point to propagate a notification payload through the service.
-    func didReceiveRemoteNotification(_ payload: Payload) async throws -> Bool
+    func didReceiveRemoteNotification(_ userInfo: UserInfo) async throws -> Bool
 
     /// Schedule a local notification to be presented.
     func localNotificationRequest(_ request: UserNotification.Request) throws

--- a/Sources/Notification/RemoteNotification.swift
+++ b/Sources/Notification/RemoteNotification.swift
@@ -3,5 +3,12 @@ public protocol RemoteNotification {
     var aps: APS { get }
 
     /// Dictionary representation of the notification.
-    var payload: Payload { get }
+    var userInfo: UserInfo { get }
+}
+
+public extension RemoteNotification {
+    @available(*, deprecated, renamed: "userInfo")
+    var payload: Payload {
+        userInfo
+    }
 }

--- a/Sources/Notification/Types/Traffic.swift
+++ b/Sources/Notification/Types/Traffic.swift
@@ -2,7 +2,7 @@ public enum Traffic: Hashable, Sendable {
     case silent(UserNotification.Payload)
     case presented(UserNotification.Payload)
     #if os(tvOS)
-    case interacted(UserNotification.Payload, ())
+    case interacted(UserNotification.Payload)
     #else
     case interacted(UserNotification.Payload, UserNotification.Action)
     #endif
@@ -23,7 +23,7 @@ public enum Traffic: Hashable, Sendable {
     @available(*, deprecated, message: "Use `UserNotification.Payload`")
     public static func interacted(_ userInfo: UserInfo) -> Traffic {
         let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
-        return .interacted(payload, ())
+        return .interacted(payload)
     }
     #else
     @available(*, deprecated, message: "Use `UserNotification.Payload`")

--- a/Sources/Notification/Types/Traffic.swift
+++ b/Sources/Notification/Types/Traffic.swift
@@ -1,9 +1,35 @@
-public enum Traffic {
-    case silent(UserInfo)
-    case presented(UserInfo)
+public enum Traffic: Hashable, Sendable {
+    case silent(UserNotification.Payload)
+    case presented(UserNotification.Payload)
     #if os(tvOS)
-    case interacted(UserInfo, ())
+    case interacted(UserNotification.Payload, ())
     #else
-    case interacted(UserInfo, UserNotification.Action)
+    case interacted(UserNotification.Payload, UserNotification.Action)
+    #endif
+
+    @available(*, deprecated, message: "Use `UserNotification.Payload`")
+    public static func silent(_ userInfo: UserInfo) -> Traffic {
+        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
+        return .silent(payload)
+    }
+
+    @available(*, deprecated, message: "Use `UserNotification.Payload`")
+    public static func presented(_ userInfo: UserInfo) -> Traffic {
+        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
+        return .presented(payload)
+    }
+
+    #if os(tvOS)
+    @available(*, deprecated, message: "Use `UserNotification.Payload`")
+    public static func interacted(_ userInfo: UserInfo) -> Traffic {
+        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
+        return .interacted(payload, ())
+    }
+    #else
+    @available(*, deprecated, message: "Use `UserNotification.Payload`")
+    public static func interacted(_ userInfo: UserInfo, _ action: UserNotification.Action) -> Traffic {
+        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
+        return .interacted(payload, action)
+    }
     #endif
 }

--- a/Sources/Notification/Types/Traffic.swift
+++ b/Sources/Notification/Types/Traffic.swift
@@ -1,9 +1,9 @@
 public enum Traffic {
-    case silent(Payload)
-    case presented(Payload)
+    case silent(UserInfo)
+    case presented(UserInfo)
     #if os(tvOS)
-    case interacted(Payload, ())
+    case interacted(UserInfo, ())
     #else
-    case interacted(Payload, UserNotification.Action)
+    case interacted(UserInfo, UserNotification.Action)
     #endif
 }

--- a/Sources/Notification/Types/UserNotification+Content.swift
+++ b/Sources/Notification/Types/UserNotification+Content.swift
@@ -23,7 +23,7 @@ public extension UserNotification {
         /// Apps can set the userInfo for locally scheduled notification requests.
         ///
         /// The contents of the push payload will be set as the userInfo for remote notifications.
-        public let payload: Payload
+        public let userInfo: UserInfo
 
         public init(
             attachments: [UserNotification.Attachment] = [],
@@ -35,7 +35,7 @@ public extension UserNotification {
             subtitle: String = "",
             threadIdentifier: String = "",
             title: String = "",
-            payload: Payload = Payload()
+            userInfo: UserInfo = UserInfo()
         ) {
             self.attachments = attachments
             self.badge = badge
@@ -46,7 +46,45 @@ public extension UserNotification {
             self.subtitle = subtitle
             self.threadIdentifier = threadIdentifier
             self.title = title
-            self.payload = payload
+            self.userInfo = userInfo
+        }
+
+        @available(*, deprecated, renamed: "init(attachments:badge:body:categoryId:launchImageName:sound:subtitle:threadIdentifier:title:userInfo:)")
+        public init(
+            attachments: [UserNotification.Attachment] = [],
+            badge: Int? = nil,
+            body: String = "",
+            categoryId: UserNotification.Category.ID = "",
+            launchImageName: String = "",
+            sound: UserNotification.Sound? = nil,
+            subtitle: String = "",
+            threadIdentifier: String = "",
+            title: String = "",
+            payload: Notification.Payload
+        ) {
+            self.attachments = attachments
+            self.badge = badge
+            self.body = body
+            self.categoryId = categoryId
+            self.launchImageName = launchImageName
+            self.sound = sound
+            self.subtitle = subtitle
+            self.threadIdentifier = threadIdentifier
+            self.title = title
+            userInfo = payload
+        }
+
+        @available(*, deprecated, renamed: "userInfo")
+        public var payload: Notification.Payload {
+            userInfo
+        }
+
+        public var aps: APS? {
+            guard let dictionary = userInfo["aps"] as? [String: Any] else {
+                return nil
+            }
+
+            return try? APS(dictionary: dictionary)
         }
     }
 }
@@ -66,7 +104,7 @@ extension UserNotification.Content: CustomDebugStringConvertible {
           subtitle: \(subtitle)
           threadIdentifier: \(threadIdentifier)
           title: \(title)
-          payload: \(payload.debugDescription)
+          userInfo: \(userInfo.debugDescription)
         }
         """
     }

--- a/Sources/Notification/Types/UserNotification+Payload.swift
+++ b/Sources/Notification/Types/UserNotification+Payload.swift
@@ -1,0 +1,99 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+
+public extension UserNotification {
+    /// A type-safe representation of `UserInfo`.
+    typealias Payload = [String: PayloadValue]
+
+    enum PayloadValue: Hashable, Sendable {
+        case bool(Bool)
+        case data(Data)
+        case date(Date)
+        case double(Double)
+        case int(Int)
+        case string(String)
+        case array([PayloadValue])
+        case dictionary([String: PayloadValue])
+
+        public init(_ any: Any) throws {
+            switch any {
+            case let value as Bool:
+                self = .bool(value)
+            case let value as Data:
+                self = .data(value)
+            case let value as Date:
+                self = .date(value)
+            case let value as Double:
+                self = .double(value)
+            case let value as Int:
+                self = .int(value)
+            case let value as String:
+                self = .string(value)
+            case let value as [Any]:
+                let values = try value.map { try PayloadValue($0) }
+                self = .array(values)
+            case let value as [String: Any]:
+                let collection = try value.mapValues { try PayloadValue($0) }
+                self = .dictionary(collection)
+            default:
+                let context = DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Unhandled Type"
+                )
+                throw DecodingError.typeMismatch(type(of: any), context)
+            }
+        }
+
+        public var userInfo: Any {
+            switch self {
+            case .bool(let value): value
+            case .data(let value): value
+            case .date(let value): value
+            case .double(let value): value
+            case .int(let value): value
+            case .string(let value): value
+            case .array(let value): value.map(\.userInfo)
+            case .dictionary(let value): value.mapValues(\.userInfo)
+            }
+        }
+
+        public var metadataValue: Logger.MetadataValue {
+            switch self {
+            case .bool(let value): .stringConvertible(value)
+            case .data(let value): .stringConvertible(value)
+            case .date(let value): .stringConvertible(value)
+            case .double(let value): .stringConvertible(value)
+            case .int(let value): .stringConvertible(value)
+            case .string(let value): .string(value)
+            case .array(let value): .array(value.map(\.metadataValue))
+            case .dictionary(let value): .dictionary(value.mapValues(\.metadataValue))
+            }
+        }
+    }
+}
+
+public extension UserNotification.Payload {
+    init(userInfo: UserInfo) throws {
+        guard let dictionary = userInfo as? [String: Any] else {
+            let context = DecodingError.Context(
+                codingPath: [],
+                debugDescription: ""
+            )
+            throw DecodingError.dataCorrupted(context)
+        }
+
+        self = try dictionary.mapValues { try UserNotification.PayloadValue($0) }
+    }
+
+    var userInfo: UserInfo {
+        mapValues(\.userInfo)
+    }
+
+    var metadata: Logger.Metadata {
+        mapValues(\.metadataValue)
+    }
+}

--- a/Sources/Notification/UserInfo.swift
+++ b/Sources/Notification/UserInfo.swift
@@ -15,6 +15,7 @@ public typealias UserInfo = [AnyHashable: Any]
 public typealias Payload = UserInfo
 
 public extension UserInfo {
+    @available(*, deprecated)
     func json(redacting keyPaths: [String] = []) -> String {
         (try? JSONSerialization.json(withJSONObject: self, redacting: keyPaths)) ?? "{}"
     }
@@ -27,6 +28,7 @@ public extension JSONSerialization {
     ///   - object: The Dictionary<String, Any> to process
     ///   - keyPaths: The _dotted_ paths that should be redacted.
     /// - returns: A `Dictionary<String, Any>` or the original `object` if not conforming.
+    @available(*, deprecated)
     static func redact(_ object: Any, keyPathsToRedact keyPaths: [String] = []) -> Any {
         guard var dictionary = object as? [String: Any] else {
             return object
@@ -61,6 +63,7 @@ public extension JSONSerialization {
     ///   - object: The object from which to generate JSON data.
     ///   - options: Options for creating the JSON data. See `JSONSerialization.WritingOptions` for possible values.
     ///   - keyPaths: The _dotted_ paths that should be redacted.
+    @available(*, deprecated)
     static func json(
         withJSONObject object: Any,
         options: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys],

--- a/Sources/Notification/UserInfo.swift
+++ b/Sources/Notification/UserInfo.swift
@@ -1,8 +1,20 @@
 import Foundation
 
-public typealias Payload = [AnyHashable: Any]
+/// Represents the dictionary associated to Notification payloads.
+///
+/// Heavily influenced by `UNNotification.request.content.userInfo`.
+///
+/// From the documentation:
+/// ```
+/// The keys in this dictionary must be property-list types—that’s,
+/// they must be types that can be serialized into the property-list format.
+/// ```
+public typealias UserInfo = [AnyHashable: Any]
 
-public extension Payload {
+@available(*, deprecated, renamed: "UserInfo")
+public typealias Payload = UserInfo
+
+public extension UserInfo {
     func json(redacting keyPaths: [String] = []) -> String {
         (try? JSONSerialization.json(withJSONObject: self, redacting: keyPaths)) ?? "{}"
     }

--- a/Sources/Notification/UserNotifications/UNNotificationContent+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationContent+Notification.swift
@@ -26,7 +26,7 @@ public extension UserNotification.Content {
             subtitle: notificationContent.subtitle,
             threadIdentifier: notificationContent.threadIdentifier,
             title: notificationContent.title,
-            payload: notificationContent.userInfo
+            userInfo: notificationContent.userInfo
         )
         #endif
     }
@@ -49,7 +49,7 @@ public extension UNNotificationContent {
         content.subtitle = notificationContent.subtitle
         content.threadIdentifier = notificationContent.threadIdentifier
         content.title = notificationContent.title
-        content.userInfo = notificationContent.payload
+        content.userInfo = notificationContent.userInfo
         #endif
         return content
     }

--- a/Sources/Notification/UserNotifications/UserNotificationManager.swift
+++ b/Sources/Notification/UserNotifications/UserNotificationManager.swift
@@ -87,9 +87,10 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         // Consider yielding UserNotification.Content instead of Payload…
         #if !os(tvOS)
-        let payload = notification.request.content.userInfo
+        let userInfo = notification.request.content.userInfo
+        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
         let metadata: Logger.Metadata = [
-            "payload": .string(payload.json(redacting: redactions)),
+            "payload": .dictionary(payload.metadata.redacting(keyPaths: redactions)),
         ]
         logger.debug("Presenting Notification", metadata: metadata)
         yieldTraffic(.presented(payload))
@@ -102,7 +103,8 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
 
     #if !os(tvOS)
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        let payload = response.notification.request.content.userInfo
+        let userInfo = response.notification.request.content.userInfo
+        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
 
         let action: UserNotification.Action = switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier:
@@ -114,7 +116,7 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
         }
 
         let metadata: Logger.Metadata = [
-            "payload": .string(payload.json(redacting: redactions)),
+            "payload": .dictionary(payload.metadata.redacting(keyPaths: redactions)),
         ]
         logger.debug("Interacted With Notification", metadata: metadata)
         yieldTraffic(.interacted(payload, action))

--- a/Tests/NotificationTests/NotificationManagerTests.swift
+++ b/Tests/NotificationTests/NotificationManagerTests.swift
@@ -15,10 +15,10 @@ final class NotificationManagerTests: XCTestCase {
             self.category = category
         }
 
-        var payload: Payload {
-            var content = Payload()
+        var userInfo: UserInfo {
+            var content = UserInfo()
 
-            if let notificationContent = aps.payload {
+            if let notificationContent = aps.userInfo {
                 content.merge(notificationContent) { _, overwrite in
                     overwrite
                 }
@@ -58,16 +58,16 @@ final class NotificationManagerTests: XCTestCase {
             .store(in: &cancelStore)
 
         if let content = aps1.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: content))
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: content))
             try notificationManager.localNotificationRequest(request)
         }
 
         let aPush = APushNotification(aps: aps2, category: "Testing")
-        let request2 = UserNotification.Request(content: UserNotification.Content(payload: aPush.payload))
+        let request2 = UserNotification.Request(content: UserNotification.Content(userInfo: aPush.payload))
         try notificationManager.localNotificationRequest(request2)
 
         if let content = aps3.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: content))
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: content))
             try notificationManager.localNotificationRequest(request)
         }
 
@@ -95,17 +95,17 @@ final class NotificationManagerTests: XCTestCase {
             }
         }
 
-        if let content = aps1.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: content))
+        if let content = aps1.userInfo {
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: content))
             try notificationManager.localNotificationRequest(request)
         }
 
         let aPush = APushNotification(aps: aps2, category: "Testing")
-        let request2 = UserNotification.Request(content: UserNotification.Content(payload: aPush.payload))
+        let request2 = UserNotification.Request(content: UserNotification.Content(userInfo: aPush.userInfo))
         try notificationManager.localNotificationRequest(request2)
 
-        if let content = aps3.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: content))
+        if let content = aps3.userInfo {
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: content))
             try notificationManager.localNotificationRequest(request)
         }
 
@@ -129,18 +129,18 @@ final class NotificationManagerTests: XCTestCase {
 
         try await Task.sleep(nanoseconds: 100_000_000)
 
-        if let payload = aps1.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: payload))
+        if let payload = aps1.userInfo {
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: payload))
             try notificationManager.localNotificationRequest(request)
         }
 
-        if let payload = aps2.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: payload))
+        if let payload = aps2.userInfo {
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: payload))
             try notificationManager.localNotificationRequest(request)
         }
 
-        if let payload = aps3.payload {
-            let request = UserNotification.Request(content: UserNotification.Content(payload: payload))
+        if let payload = aps3.userInfo {
+            let request = UserNotification.Request(content: UserNotification.Content(userInfo: payload))
             try notificationManager.localNotificationRequest(request)
         }
 

--- a/Tests/NotificationTests/PayloadTests.swift
+++ b/Tests/NotificationTests/PayloadTests.swift
@@ -1,0 +1,61 @@
+@testable import Notification
+import XCTest
+
+final class PayloadTests: XCTestCase {
+
+    func testActionableNotificationUserInfo() throws {
+        let userInfo: UserInfo = [
+            "aps": [
+                "alert": [
+                    "title": "Meeting Request",
+                    "body": "Bob wants to schedule a design review.",
+                ],
+                "category": "MEETING_INVITE_CATEGORY",
+            ],
+            "meeting_id": "mtg_404",
+        ]
+
+        let payload = try UserNotification.Payload(userInfo: userInfo)
+
+        XCTAssertEqual(payload, [
+            "aps": .dictionary([
+                "alert": .dictionary([
+                    "title": .string("Meeting Request"),
+                    "body": .string("Bob wants to schedule a design review."),
+                ]),
+                "category": .string("MEETING_INVITE_CATEGORY"),
+            ]),
+            "meeting_id": .string("mtg_404"),
+        ])
+    }
+
+    func testCustomDataNotificationUserInfo() throws {
+        let userInfo: UserInfo = [
+            "aps": [
+                "alert": [
+                    "title": "New Document Shared",
+                    "body": "Alice shared 'Q3_Report.pdf' with you.",
+                ],
+                "badge": 1,
+                "sound": "default",
+            ],
+            "document_id": "doc_8675309",
+            "shared_by_user_id": "usr_123",
+        ]
+
+        let payload = try UserNotification.Payload(userInfo: userInfo)
+
+        XCTAssertEqual(payload, [
+            "aps": .dictionary([
+                "alert": .dictionary([
+                    "title": .string("New Document Shared"),
+                    "body": .string("Alice shared 'Q3_Report.pdf' with you."),
+                ]),
+                "badge": .int(1),
+                "sound": .string("default"),
+            ]),
+            "document_id": .string("doc_8675309"),
+            "shared_by_user_id": .string("usr_123"),
+        ])
+    }
+}

--- a/Tests/NotificationTests/RedactionTests.swift
+++ b/Tests/NotificationTests/RedactionTests.swift
@@ -1,0 +1,39 @@
+import Logging
+@testable import Notification
+import XCTest
+
+final class RedactionTests: XCTestCase {
+
+    func testRedactions() {
+        let metadata: Logger.Metadata = [
+            "agent": .string("Awesome"),
+            "identities": .array([
+                .string("Bob Barker"),
+                .string("Will Rogers"),
+            ]),
+            "values": .dictionary([
+                "pie": .string("Cherry"),
+                "pi": .stringConvertible(3.14),
+            ]),
+        ]
+
+        let redacted = metadata.redacting(
+            keyPaths: [
+                "identities",
+                "values.pie",
+            ]
+        )
+
+        XCTAssertEqual(
+            redacted,
+            [
+                "agent": .string("Awesome"),
+                "identities": .string("<REDACTED>"),
+                "values": .dictionary([
+                    "pie": .string("<REDACTED>"),
+                    "pi": .stringConvertible(3.14),
+                ]),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
`Payload` (a typealias to `[AnyHashable: Any]`) was renamed to `UserInfo`, paving the way to reuse _Payload_ in the `UserNotification` space.

The new _Payload_, is a type safe representation that now conforms to `Hashable` & `Sendable`, and replaces `UserInfo` as the output associated to `Traffic`.