### PR TITLE
Re-elevated Payload

### DIFF
--- a/Sources/Notification/APNS/APS.swift
+++ b/Sources/Notification/APNS/APS.swift
@@ -52,33 +52,14 @@ public struct APS: Hashable, Sendable {
         self.threadId = threadId
     }
 
+    @available(*, deprecated)
     public init(dictionary: [String: Any]) throws {
         let data = try JSONSerialization.data(withJSONObject: dictionary)
         self = try JSONDecoder().decode(Self.self, from: data)
     }
 
-    public var payload: UserNotification.Payload {
-        var content = UserNotification.Payload()
-        if let alert {
-            content[CodingKeys.alert.rawValue] = .dictionary(alert.payload)
-        }
-        if let badge {
-            content[CodingKeys.badge.rawValue] = .int(badge)
-        }
-        if let sound {
-            content[CodingKeys.sound.rawValue] = .string(sound)
-        }
-        if let contentAvailable {
-            content[CodingKeys.contentAvailable.rawValue] = .int(contentAvailable)
-        }
-        if let category {
-            content[CodingKeys.category.rawValue] = .string(category)
-        }
-        if let threadId {
-            content[CodingKeys.threadId.rawValue] = .string(threadId)
-        }
-        return content
-    }
+    /// Indicates if the `contentAvailable` flag has been set in the affirmative.
+    public var isSilent: Bool { contentAvailable == 1 }
 }
 
 extension APS: Codable {
@@ -113,7 +94,97 @@ extension APS: Codable {
     }
 }
 
+extension APS: ExpressibleByPayload {
+    public init(payload: Payload) throws {
+        if payload.contains(where: { $0.key == CodingKeys.alert.rawValue }) {
+            guard case .dictionary(let aps) = payload[CodingKeys.alert.rawValue] else {
+                throw DecodingError.typeMismatch(Alert.self, DecodingError.Context(codingPath: [CodingKeys.alert], debugDescription: ""))
+            }
+
+            alert = try Alert(payload: aps)
+        } else {
+            alert = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.badge.rawValue }) {
+            guard case .int(let badge) = payload[CodingKeys.badge.rawValue] else {
+                throw DecodingError.typeMismatch(Int.self, DecodingError.Context(codingPath: [CodingKeys.badge], debugDescription: ""))
+            }
+
+            self.badge = badge
+        } else {
+            badge = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.sound.rawValue }) {
+            guard case .string(let sound) = payload[CodingKeys.sound.rawValue] else {
+                throw DecodingError.typeMismatch(Int.self, DecodingError.Context(codingPath: [CodingKeys.sound], debugDescription: ""))
+            }
+
+            self.sound = sound
+        } else {
+            sound = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.contentAvailable.rawValue }) {
+            guard case .int(let contentAvailable) = payload[CodingKeys.contentAvailable.rawValue] else {
+                throw DecodingError.typeMismatch(Int.self, DecodingError.Context(codingPath: [CodingKeys.contentAvailable], debugDescription: ""))
+            }
+
+            self.contentAvailable = contentAvailable
+        } else {
+            contentAvailable = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.category.rawValue }) {
+            guard case .string(let category) = payload[CodingKeys.category.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.category], debugDescription: ""))
+            }
+
+            self.category = category
+        } else {
+            category = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.threadId.rawValue }) {
+            guard case .string(let threadId) = payload[CodingKeys.threadId.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.threadId], debugDescription: ""))
+            }
+
+            self.threadId = threadId
+        } else {
+            threadId = nil
+        }
+    }
+}
+
+extension APS: PayloadConvertible {
+    public var payload: Payload {
+        var content = Payload()
+        if let alert {
+            content[CodingKeys.alert.rawValue] = .dictionary(alert.payload)
+        }
+        if let badge {
+            content[CodingKeys.badge.rawValue] = .int(badge)
+        }
+        if let sound {
+            content[CodingKeys.sound.rawValue] = .string(sound)
+        }
+        if let contentAvailable {
+            content[CodingKeys.contentAvailable.rawValue] = .int(contentAvailable)
+        }
+        if let category {
+            content[CodingKeys.category.rawValue] = .string(category)
+        }
+        if let threadId {
+            content[CodingKeys.threadId.rawValue] = .string(threadId)
+        }
+        return content
+    }
+}
+
 public extension APS {
+    @available(*, deprecated, renamed: "payload")
     var userInfo: UserInfo? {
         guard let data = try? JSONEncoder().encode(self) else {
             return nil
@@ -124,23 +195,5 @@ public extension APS {
         }
 
         return ["aps": dictionary]
-    }
-
-    /// Indicates if the `contentAvailable` flag has been set in the affirmative.
-    var isSilent: Bool { contentAvailable == 1 }
-}
-
-public extension UserInfo {
-    @available(*, deprecated)
-    var aps: APS? {
-        guard let dictionary = self["aps"] else {
-            return nil
-        }
-
-        guard let data = try? JSONSerialization.data(withJSONObject: dictionary) else {
-            return nil
-        }
-
-        return try? JSONDecoder().decode(APS.self, from: data)
     }
 }

--- a/Sources/Notification/APNS/Alert.swift
+++ b/Sources/Notification/APNS/Alert.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Push Notification Alert Content
 ///
 /// [Localization of Content](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW9)
@@ -60,35 +58,6 @@ public struct Alert: Hashable, Sendable {
         self.actionLocalizationKey = actionLocalizationKey
         self.launchImage = launchImage
     }
-
-    public var payload: UserNotification.Payload {
-        var content = UserNotification.Payload()
-        if let title {
-            content[CodingKeys.title.rawValue] = .string(title)
-        }
-        if let body {
-            content[CodingKeys.body.rawValue] = .string(body)
-        }
-        if let titleLocalizationKey {
-            content[CodingKeys.titleLocalizationKey.rawValue] = .string(titleLocalizationKey)
-        }
-        if let titleLocalizationArguments {
-            content[CodingKeys.titleLocalizationArguments.rawValue] = .array(titleLocalizationArguments.map { UserNotification.PayloadValue.string($0) })
-        }
-        if let bodyLocalizationKey {
-            content[CodingKeys.bodyLocalizationKey.rawValue] = .string(bodyLocalizationKey)
-        }
-        if let bodyLocalizationArguments {
-            content[CodingKeys.bodyLocalizationArguments.rawValue] = .array(bodyLocalizationArguments.map { UserNotification.PayloadValue.string($0) })
-        }
-        if let actionLocalizationKey {
-            content[CodingKeys.actionLocalizationKey.rawValue] = .string(actionLocalizationKey)
-        }
-        if let launchImage {
-            content[CodingKeys.launchImage.rawValue] = .string(launchImage)
-        }
-        return content
-    }
 }
 
 extension Alert: Codable {
@@ -101,5 +70,132 @@ extension Alert: Codable {
         case bodyLocalizationArguments = "loc-arg"
         case actionLocalizationKey = "action-loc-key"
         case launchImage = "launch-image"
+    }
+}
+
+extension Alert: ExpressibleByPayload {
+    public init(payload: Payload) throws {
+        if payload.contains(where: { $0.key == CodingKeys.title.rawValue }) {
+            guard case .string(let title) = payload[CodingKeys.title.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.title], debugDescription: ""))
+            }
+
+            self.title = title
+        } else {
+            title = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.body.rawValue }) {
+            guard case .string(let body) = payload[CodingKeys.body.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.body], debugDescription: ""))
+            }
+
+            self.body = body
+        } else {
+            body = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.titleLocalizationKey.rawValue }) {
+            guard case .string(let titleLocalizationKey) = payload[CodingKeys.titleLocalizationKey.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.titleLocalizationKey], debugDescription: ""))
+            }
+
+            self.titleLocalizationKey = titleLocalizationKey
+        } else {
+            titleLocalizationKey = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.titleLocalizationArguments.rawValue }) {
+            guard case .array(let titleLocalizationArguments) = payload[CodingKeys.titleLocalizationArguments.rawValue] else {
+                throw DecodingError.typeMismatch([String].self, DecodingError.Context(codingPath: [CodingKeys.titleLocalizationArguments], debugDescription: ""))
+            }
+
+            self.titleLocalizationArguments = try titleLocalizationArguments.map { argument in
+                guard case .string(let value) = argument else {
+                    throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.titleLocalizationArguments], debugDescription: ""))
+                }
+
+                return value
+            }
+        } else {
+            titleLocalizationArguments = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.bodyLocalizationKey.rawValue }) {
+            guard case .string(let bodyLocalizationKey) = payload[CodingKeys.bodyLocalizationKey.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.bodyLocalizationKey], debugDescription: ""))
+            }
+
+            self.bodyLocalizationKey = bodyLocalizationKey
+        } else {
+            bodyLocalizationKey = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.bodyLocalizationArguments.rawValue }) {
+            guard case .array(let bodyLocalizationArguments) = payload[CodingKeys.bodyLocalizationArguments.rawValue] else {
+                throw DecodingError.typeMismatch([String].self, DecodingError.Context(codingPath: [CodingKeys.bodyLocalizationArguments], debugDescription: ""))
+            }
+
+            self.bodyLocalizationArguments = try bodyLocalizationArguments.map { argument in
+                guard case .string(let value) = argument else {
+                    throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.bodyLocalizationArguments], debugDescription: ""))
+                }
+
+                return value
+            }
+        } else {
+            bodyLocalizationArguments = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.actionLocalizationKey.rawValue }) {
+            guard case .string(let actionLocalizationKey) = payload[CodingKeys.actionLocalizationKey.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.actionLocalizationKey], debugDescription: ""))
+            }
+
+            self.actionLocalizationKey = actionLocalizationKey
+        } else {
+            actionLocalizationKey = nil
+        }
+
+        if payload.contains(where: { $0.key == CodingKeys.launchImage.rawValue }) {
+            guard case .string(let launchImage) = payload[CodingKeys.launchImage.rawValue] else {
+                throw DecodingError.typeMismatch(String.self, DecodingError.Context(codingPath: [CodingKeys.launchImage], debugDescription: ""))
+            }
+
+            self.launchImage = launchImage
+        } else {
+            launchImage = nil
+        }
+    }
+}
+
+extension Alert: PayloadConvertible {
+    public var payload: Payload {
+        var content = Payload()
+        if let title {
+            content[CodingKeys.title.rawValue] = .string(title)
+        }
+        if let body {
+            content[CodingKeys.body.rawValue] = .string(body)
+        }
+        if let titleLocalizationKey {
+            content[CodingKeys.titleLocalizationKey.rawValue] = .string(titleLocalizationKey)
+        }
+        if let titleLocalizationArguments {
+            content[CodingKeys.titleLocalizationArguments.rawValue] = .array(titleLocalizationArguments.map { PayloadValue.string($0) })
+        }
+        if let bodyLocalizationKey {
+            content[CodingKeys.bodyLocalizationKey.rawValue] = .string(bodyLocalizationKey)
+        }
+        if let bodyLocalizationArguments {
+            content[CodingKeys.bodyLocalizationArguments.rawValue] = .array(bodyLocalizationArguments.map { PayloadValue.string($0) })
+        }
+        if let actionLocalizationKey {
+            content[CodingKeys.actionLocalizationKey.rawValue] = .string(actionLocalizationKey)
+        }
+        if let launchImage {
+            content[CodingKeys.launchImage.rawValue] = .string(launchImage)
+        }
+        return content
     }
 }

--- a/Sources/Notification/AbstractNotificationManager.swift
+++ b/Sources/Notification/AbstractNotificationManager.swift
@@ -55,7 +55,7 @@ open class AbstractNotificationManager: NSObject, NotificationManager {
     }
 
     public func didReceiveRemoteNotification(_ userInfo: UserInfo) async throws -> Bool {
-        let payload = try UserNotification.Payload(userInfo: userInfo)
+        let payload = try Payload(userInfo: userInfo)
         let metadata: Logger.Metadata = [
             "payload": .dictionary(payload.metadata.redacting(keyPaths: redactions)),
         ]

--- a/Sources/Notification/EmulatedNotificationManager.swift
+++ b/Sources/Notification/EmulatedNotificationManager.swift
@@ -62,10 +62,14 @@ open class EmulatedNotificationManager: AbstractNotificationManager {
     }
 
     override public func localNotificationRequest(_ request: UserNotification.Request) throws {
-        let userInfo = request.content.userInfo
-        let payload = try UserNotification.Payload(userInfo: userInfo)
+        let payload = request.content.payload
+        let aps: APS? = if case .dictionary(let apsPayload) = payload["aps"] {
+            try APS(payload: apsPayload)
+        } else {
+            nil
+        }
 
-        let traffic: Traffic = if request.content.aps?.isSilent == true {
+        let traffic: Traffic = if aps?.isSilent == true {
             .silent(payload)
         } else {
             #if os(tvOS)

--- a/Sources/Notification/Extensions/Logger.Metadata+Notification.swift
+++ b/Sources/Notification/Extensions/Logger.Metadata+Notification.swift
@@ -1,6 +1,11 @@
 import Logging
 
 extension Logger.Metadata {
+    /// Recurses through the instance and redacts any values associated to the specified paths.
+    ///
+    /// - parameters:
+    ///   - keyPaths: Collection of _dotted_ paths that should have their values redacted.
+    ///   - redaction: The value to put in place of those that are identified.
     func redacting(keyPaths: [String] = [], with redaction: String = "<REDACTED>") -> Self {
         var dictionary = self
 

--- a/Sources/Notification/Firebase/FCMMetadata.swift
+++ b/Sources/Notification/Firebase/FCMMetadata.swift
@@ -32,23 +32,6 @@ public struct FCMMetadata: Hashable, Sendable {
         self.installationId = installationId
         self.analyticsEnabled = analyticsEnabled
     }
-
-    public var payload: UserNotification.Payload {
-        var content = UserNotification.Payload()
-        if let messageId {
-            content[CodingKeys.messageId.rawValue] = .string(messageId)
-        }
-        if let senderId {
-            content[CodingKeys.senderId.rawValue] = .string(senderId)
-        }
-        if let installationId {
-            content[CodingKeys.installationId.rawValue] = .string(installationId)
-        }
-        if let analyticsEnabled {
-            content[CodingKeys.analyticsEnabled.rawValue] = .int(analyticsEnabled)
-        }
-        return content
-    }
 }
 
 extension FCMMetadata: Codable {
@@ -76,5 +59,24 @@ extension FCMMetadata: Codable {
         } catch {
             analyticsEnabled = nil
         }
+    }
+}
+
+extension FCMMetadata: PayloadConvertible {
+    public var payload: Payload {
+        var content = Payload()
+        if let messageId {
+            content[CodingKeys.messageId.rawValue] = .string(messageId)
+        }
+        if let senderId {
+            content[CodingKeys.senderId.rawValue] = .string(senderId)
+        }
+        if let installationId {
+            content[CodingKeys.installationId.rawValue] = .string(installationId)
+        }
+        if let analyticsEnabled {
+            content[CodingKeys.analyticsEnabled.rawValue] = .int(analyticsEnabled)
+        }
+        return content
     }
 }

--- a/Sources/Notification/Firebase/FCMOptions.swift
+++ b/Sources/Notification/Firebase/FCMOptions.swift
@@ -10,14 +10,6 @@ public struct FCMOptions: Hashable, Sendable, Codable {
         self.image = image
     }
 
-    public var payload: UserNotification.Payload {
-        var content = UserNotification.Payload()
-        if let image {
-            content["image"] = .string(image.absoluteString)
-        }
-        return content
-    }
-
     @available(*, deprecated)
     var userInfo: UserInfo {
         if let image {
@@ -29,5 +21,15 @@ public struct FCMOptions: Hashable, Sendable, Codable {
         } else {
             [:]
         }
+    }
+}
+
+extension FCMOptions: PayloadConvertible {
+    public var payload: Payload {
+        var content = Payload()
+        if let image {
+            content["image"] = .string(image.absoluteString)
+        }
+        return content
     }
 }

--- a/Sources/Notification/Firebase/FMCNotification.swift
+++ b/Sources/Notification/Firebase/FMCNotification.swift
@@ -1,11 +1,11 @@
-public protocol FCMNotification: RemoteNotification {
+public protocol FCMNotification: RemoteNotification, PayloadConvertible {
     var options: FCMOptions? { get }
     var metadata: FCMMetadata? { get }
 }
 
 public extension FCMNotification {
-    var payload: UserNotification.Payload {
-        var content = metadata?.payload ?? UserNotification.Payload()
+    var payload: Payload {
+        var content = metadata?.payload ?? Payload()
         content["aps"] = .dictionary(aps.payload)
         if let options {
             content["fcm_options"] = .dictionary(options.payload)
@@ -13,6 +13,7 @@ public extension FCMNotification {
         return content
     }
 
+    @available(*, deprecated, renamed: "payload")
     var userInfo: UserInfo {
         payload.userInfo
     }

--- a/Sources/Notification/Firebase/FirebaseCloudMessage.swift
+++ b/Sources/Notification/Firebase/FirebaseCloudMessage.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// A `RemoteNotification` delivered through Google/Firebase Cloud Messaging.
 public struct FirebaseCloudMessage: FCMNotification, Hashable, Sendable {
     public let aps: APS

--- a/Sources/Notification/NotificationManager.swift
+++ b/Sources/Notification/NotificationManager.swift
@@ -76,7 +76,7 @@ public extension NotificationManager {
 
         let task = Task {
             for await value in trafficStream() {
-                var notificationPayload: UserNotification.Payload
+                var notificationPayload: Payload
                 #if os(tvOS)
                 switch value {
                 case .silent(let payload), .interacted(let payload):

--- a/Sources/Notification/Payload.swift
+++ b/Sources/Notification/Payload.swift
@@ -1,0 +1,106 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+
+public typealias Payload = [String: PayloadValue]
+
+public enum PayloadValue: Hashable, Sendable {
+    case bool(Bool)
+    case data(Data)
+    case date(Date)
+    case double(Double)
+    case int(Int)
+    case string(String)
+    case array([PayloadValue])
+    case dictionary([String: PayloadValue])
+
+    public init(_ any: Any) throws {
+        switch any {
+        case let value as Bool:
+            self = .bool(value)
+        case let value as Data:
+            self = .data(value)
+        case let value as Date:
+            self = .date(value)
+        case let value as Double:
+            self = .double(value)
+        case let value as Int:
+            self = .int(value)
+        case let value as String:
+            self = .string(value)
+        case let value as [Any]:
+            let values = try value.map { try PayloadValue($0) }
+            self = .array(values)
+        case let value as [String: Any]:
+            let collection = try value.mapValues { try PayloadValue($0) }
+            self = .dictionary(collection)
+        default:
+            let context = DecodingError.Context(
+                codingPath: [],
+                debugDescription: "Unhandled Type",
+            )
+            throw DecodingError.typeMismatch(type(of: any), context)
+        }
+    }
+
+    public var userInfo: Any {
+        switch self {
+        case .bool(let value): value
+        case .data(let value): value
+        case .date(let value): value
+        case .double(let value): value
+        case .int(let value): value
+        case .string(let value): value
+        case .array(let value): value.map(\.userInfo)
+        case .dictionary(let value): value.mapValues(\.userInfo)
+        }
+    }
+
+    public var metadataValue: Logger.MetadataValue {
+        switch self {
+        case .bool(let value): .stringConvertible(value)
+        case .data(let value): .stringConvertible(value)
+        case .date(let value): .stringConvertible(value)
+        case .double(let value): .stringConvertible(value)
+        case .int(let value): .stringConvertible(value)
+        case .string(let value): .string(value)
+        case .array(let value): .array(value.map(\.metadataValue))
+        case .dictionary(let value): .dictionary(value.mapValues(\.metadataValue))
+        }
+    }
+}
+
+public extension Payload {
+    init(userInfo: UserInfo) throws {
+        guard let dictionary = userInfo as? [String: Any] else {
+            let context = DecodingError.Context(
+                codingPath: [],
+                debugDescription: "",
+            )
+            throw DecodingError.dataCorrupted(context)
+        }
+
+        self = try dictionary.mapValues { try PayloadValue($0) }
+    }
+
+    var userInfo: UserInfo {
+        mapValues(\.userInfo)
+    }
+
+    var metadata: Logger.Metadata {
+        mapValues(\.metadataValue)
+    }
+}
+
+/// A type which can be represented as a type-safe hashable/sendable dictionary.
+public protocol PayloadConvertible {
+    var payload: Payload { get }
+}
+
+/// A type which can be initialized with a type-safe hashable/sendable dictionary.
+public protocol ExpressibleByPayload {
+    init(payload: Payload) throws
+}

--- a/Sources/Notification/Types/Traffic.swift
+++ b/Sources/Notification/Types/Traffic.swift
@@ -1,10 +1,10 @@
 public enum Traffic: Hashable, Sendable {
-    case silent(UserNotification.Payload)
-    case presented(UserNotification.Payload)
+    case silent(Payload)
+    case presented(Payload)
     #if os(tvOS)
-    case interacted(UserNotification.Payload)
+    case interacted(Payload)
     #else
-    case interacted(UserNotification.Payload, UserNotification.Action)
+    case interacted(Payload, UserNotification.Action)
     #endif
 
     @available(*, deprecated, message: "Use `UserNotification.Payload`")

--- a/Sources/Notification/Types/UserNotification+Action.swift
+++ b/Sources/Notification/Types/UserNotification+Action.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public extension UserNotification {
     struct Action: Hashable, Sendable, Identifiable, Codable {
         /// The unique identifier for this action.
@@ -14,7 +12,7 @@ public extension UserNotification {
         public let foreground: Bool
 
         public init(
-            id: String = UUID().uuidString,
+            id: String = "",
             title: String = "",
             authenticationRequired: Bool = false,
             destructive: Bool = false,

--- a/Sources/Notification/Types/UserNotification+Category.swift
+++ b/Sources/Notification/Types/UserNotification+Category.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public extension UserNotification {
     struct Category: Hashable, Sendable, Identifiable, Codable {
 
@@ -7,7 +5,7 @@ public extension UserNotification {
         public let actions: [Action]
 
         public init(
-            id: String = UUID().uuidString,
+            id: String = "",
             actions: [Action] = [],
         ) {
             self.id = id

--- a/Sources/Notification/Types/UserNotification+Content.swift
+++ b/Sources/Notification/Types/UserNotification+Content.swift
@@ -1,5 +1,5 @@
 public extension UserNotification {
-    struct Content {
+    struct Content: Hashable, Sendable {
         /// Optional array of attachments.
         public let attachments: [Attachment]
         /// The application badge number.
@@ -23,7 +23,7 @@ public extension UserNotification {
         /// Apps can set the userInfo for locally scheduled notification requests.
         ///
         /// The contents of the push payload will be set as the userInfo for remote notifications.
-        public let userInfo: UserInfo
+        public let payload: Notification.Payload
 
         public init(
             attachments: [UserNotification.Attachment] = [],
@@ -35,7 +35,7 @@ public extension UserNotification {
             subtitle: String = "",
             threadIdentifier: String = "",
             title: String = "",
-            userInfo: UserInfo = UserInfo(),
+            payload: Notification.Payload = Notification.Payload(),
         ) {
             self.attachments = attachments
             self.badge = badge
@@ -46,10 +46,10 @@ public extension UserNotification {
             self.subtitle = subtitle
             self.threadIdentifier = threadIdentifier
             self.title = title
-            self.userInfo = userInfo
+            self.payload = payload
         }
 
-        @available(*, deprecated, renamed: "init(attachments:badge:body:categoryId:launchImageName:sound:subtitle:threadIdentifier:title:userInfo:)")
+        @available(*, deprecated, renamed: "init(attachments:badge:body:categoryId:launchImageName:sound:subtitle:threadIdentifier:title:payload:)")
         public init(
             attachments: [UserNotification.Attachment] = [],
             badge: Int? = nil,
@@ -60,8 +60,8 @@ public extension UserNotification {
             subtitle: String = "",
             threadIdentifier: String = "",
             title: String = "",
-            payload: Notification.Payload,
-        ) {
+            userInfo: UserInfo,
+        ) throws {
             self.attachments = attachments
             self.badge = badge
             self.body = body
@@ -71,21 +71,24 @@ public extension UserNotification {
             self.subtitle = subtitle
             self.threadIdentifier = threadIdentifier
             self.title = title
-            userInfo = payload
+            payload = try Notification.Payload(userInfo: userInfo)
+        }
+    }
+}
+
+public extension UserNotification.Content {
+    @available(*, deprecated, renamed: "payload")
+    var userInfo: UserInfo {
+        payload.userInfo
+    }
+
+    @available(*, deprecated)
+    var aps: APS? {
+        guard let dictionary = userInfo["aps"] as? [String: Any] else {
+            return nil
         }
 
-        @available(*, deprecated, renamed: "userInfo")
-        public var payload: Notification.Payload {
-            userInfo
-        }
-
-        public var aps: APS? {
-            guard let dictionary = userInfo["aps"] as? [String: Any] else {
-                return nil
-            }
-
-            return try? APS(dictionary: dictionary)
-        }
+        return try? APS(dictionary: dictionary)
     }
 }
 
@@ -104,7 +107,7 @@ extension UserNotification.Content: CustomDebugStringConvertible {
           subtitle: \(subtitle)
           threadIdentifier: \(threadIdentifier)
           title: \(title)
-          userInfo: \(userInfo.debugDescription)
+          payload: \(payload.debugDescription)
         }
         """
     }

--- a/Sources/Notification/Types/UserNotification+Payload.swift
+++ b/Sources/Notification/Types/UserNotification+Payload.swift
@@ -6,94 +6,9 @@ import Foundation
 import Logging
 
 public extension UserNotification {
-    /// A type-safe representation of `UserInfo`.
-    typealias Payload = [String: PayloadValue]
+    @available(*, deprecated)
+    typealias Payload = Notification::Payload
 
-    enum PayloadValue: Hashable, Sendable {
-        case bool(Bool)
-        case data(Data)
-        case date(Date)
-        case double(Double)
-        case int(Int)
-        case string(String)
-        case array([PayloadValue])
-        case dictionary([String: PayloadValue])
-
-        public init(_ any: Any) throws {
-            switch any {
-            case let value as Bool:
-                self = .bool(value)
-            case let value as Data:
-                self = .data(value)
-            case let value as Date:
-                self = .date(value)
-            case let value as Double:
-                self = .double(value)
-            case let value as Int:
-                self = .int(value)
-            case let value as String:
-                self = .string(value)
-            case let value as [Any]:
-                let values = try value.map { try PayloadValue($0) }
-                self = .array(values)
-            case let value as [String: Any]:
-                let collection = try value.mapValues { try PayloadValue($0) }
-                self = .dictionary(collection)
-            default:
-                let context = DecodingError.Context(
-                    codingPath: [],
-                    debugDescription: "Unhandled Type",
-                )
-                throw DecodingError.typeMismatch(type(of: any), context)
-            }
-        }
-
-        public var userInfo: Any {
-            switch self {
-            case .bool(let value): value
-            case .data(let value): value
-            case .date(let value): value
-            case .double(let value): value
-            case .int(let value): value
-            case .string(let value): value
-            case .array(let value): value.map(\.userInfo)
-            case .dictionary(let value): value.mapValues(\.userInfo)
-            }
-        }
-
-        public var metadataValue: Logger.MetadataValue {
-            switch self {
-            case .bool(let value): .stringConvertible(value)
-            case .data(let value): .stringConvertible(value)
-            case .date(let value): .stringConvertible(value)
-            case .double(let value): .stringConvertible(value)
-            case .int(let value): .stringConvertible(value)
-            case .string(let value): .string(value)
-            case .array(let value): .array(value.map(\.metadataValue))
-            case .dictionary(let value): .dictionary(value.mapValues(\.metadataValue))
-            }
-        }
-    }
-}
-
-public extension UserNotification.Payload {
-    init(userInfo: UserInfo) throws {
-        guard let dictionary = userInfo as? [String: Any] else {
-            let context = DecodingError.Context(
-                codingPath: [],
-                debugDescription: "",
-            )
-            throw DecodingError.dataCorrupted(context)
-        }
-
-        self = try dictionary.mapValues { try UserNotification.PayloadValue($0) }
-    }
-
-    var userInfo: UserInfo {
-        mapValues(\.userInfo)
-    }
-
-    var metadata: Logger.Metadata {
-        mapValues(\.metadataValue)
-    }
+    @available(*, deprecated)
+    typealias PayloadValue = Notification::PayloadValue
 }

--- a/Sources/Notification/Types/UserNotification+Request.swift
+++ b/Sources/Notification/Types/UserNotification+Request.swift
@@ -1,13 +1,11 @@
-import Foundation
-
 public extension UserNotification {
-    struct Request: Identifiable {
+    struct Request: Hashable, Sendable, Identifiable {
         public let id: String
         public let content: Content
         public let trigger: Trigger?
 
         public init(
-            id: String = UUID().uuidString,
+            id: String = "",
             content: Content = Content(),
             trigger: Trigger? = nil,
         ) {

--- a/Sources/Notification/Types/UserNotification+Trigger.swift
+++ b/Sources/Notification/Types/UserNotification+Trigger.swift
@@ -1,4 +1,8 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 public extension UserNotification {
     struct Trigger: Hashable, Sendable {

--- a/Sources/Notification/Types/UserNotification.swift
+++ b/Sources/Notification/Types/UserNotification.swift
@@ -1,6 +1,10 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
-public struct UserNotification {
+public struct UserNotification: Hashable, Sendable {
     public let date: Date
     public let request: Request
 

--- a/Sources/Notification/UserInfo.swift
+++ b/Sources/Notification/UserInfo.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Represents the dictionary associated to Notification payloads.
 ///
 /// Heavily influenced by `UNNotification.request.content.userInfo`.
@@ -10,67 +8,3 @@ import Foundation
 /// they must be types that can be serialized into the property-list format.
 /// ```
 public typealias UserInfo = [AnyHashable: Any]
-
-@available(*, deprecated, renamed: "UserInfo")
-public typealias Payload = UserInfo
-
-public extension UserInfo {
-    @available(*, deprecated)
-    func json(redacting keyPaths: [String] = []) -> String {
-        (try? JSONSerialization.json(withJSONObject: self, redacting: keyPaths)) ?? "{}"
-    }
-}
-
-public extension JSONSerialization {
-    /// Recurses `object` as a Dictionary and redacts any values identified by `keyPathsToRedact`.
-    ///
-    /// - parameters:
-    ///   - object: The Dictionary<String, Any> to process
-    ///   - keyPaths: The _dotted_ paths that should be redacted.
-    /// - returns: A `Dictionary<String, Any>` or the original `object` if not conforming.
-    @available(*, deprecated)
-    static func redact(_ object: Any, keyPathsToRedact keyPaths: [String] = []) -> Any {
-        guard var dictionary = object as? [String: Any] else {
-            return object
-        }
-
-        for keyPath in keyPaths {
-            // Extract the key for this level
-            let split = keyPath.split(separator: ".", maxSplits: 1)
-            let key = String(split[0])
-
-            guard var value = dictionary[key] else {
-                continue
-            }
-
-            if split.count > 1 {
-                // Continue down the path
-                let subPath = String(split[1])
-                value = redact(value, keyPathsToRedact: [subPath])
-            } else {
-                value = "<REDACTED>"
-            }
-
-            dictionary[key] = value
-        }
-
-        return dictionary
-    }
-
-    /// Creates a JSON representation of the object with redacted key paths.
-    ///
-    /// - parameters:
-    ///   - object: The object from which to generate JSON data.
-    ///   - options: Options for creating the JSON data. See `JSONSerialization.WritingOptions` for possible values.
-    ///   - keyPaths: The _dotted_ paths that should be redacted.
-    @available(*, deprecated)
-    static func json(
-        withJSONObject object: Any,
-        options: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys],
-        redacting keyPaths: [String] = [],
-    ) throws -> String {
-        let redactedObject = redact(object, keyPathsToRedact: keyPaths)
-        let data = try JSONSerialization.data(withJSONObject: redactedObject, options: options)
-        return String(data: data, encoding: .utf8) ?? "{}"
-    }
-}

--- a/Sources/Notification/UserNotifications/UNNotificationContent+Notification.swift
+++ b/Sources/Notification/UserNotifications/UNNotificationContent+Notification.swift
@@ -26,7 +26,7 @@ public extension UserNotification.Content {
             subtitle: notificationContent.subtitle,
             threadIdentifier: notificationContent.threadIdentifier,
             title: notificationContent.title,
-            userInfo: notificationContent.userInfo,
+            payload: (try? Payload(userInfo: notificationContent.userInfo)) ?? Payload(),
         )
         #endif
     }
@@ -49,7 +49,7 @@ public extension UNNotificationContent {
         content.subtitle = notificationContent.subtitle
         content.threadIdentifier = notificationContent.threadIdentifier
         content.title = notificationContent.title
-        content.userInfo = notificationContent.userInfo
+        content.userInfo = notificationContent.payload.userInfo
         #endif
         return content
     }

--- a/Sources/Notification/UserNotifications/UserNotificationManager.swift
+++ b/Sources/Notification/UserNotifications/UserNotificationManager.swift
@@ -88,7 +88,7 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
         // Consider yielding UserNotification.Content instead of Payload…
         #if !os(tvOS)
         let userInfo = notification.request.content.userInfo
-        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
+        let payload = (try? Payload(userInfo: userInfo)) ?? [:]
         let metadata: Logger.Metadata = [
             "payload": .dictionary(payload.metadata.redacting(keyPaths: redactions)),
         ]
@@ -104,7 +104,7 @@ extension UserNotificationManager: UNUserNotificationCenterDelegate {
     #if !os(tvOS)
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
-        let payload = (try? UserNotification.Payload(userInfo: userInfo)) ?? [:]
+        let payload = (try? Payload(userInfo: userInfo)) ?? [:]
 
         let action: UserNotification.Action = switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier:

--- a/Tests/NotificationTests/NotificationManagerTests.swift
+++ b/Tests/NotificationTests/NotificationManagerTests.swift
@@ -12,20 +12,15 @@ struct NotificationManagerTests {
             self.category = category
         }
 
-        var userInfo: UserInfo {
-            var content = UserInfo()
-
-            if let notificationContent = aps.userInfo {
-                content.merge(notificationContent) { _, overwrite in
-                    overwrite
-                }
-            }
-
-            content.merge([CodingKeys.category.stringValue: category]) { _, overwrite in
-                overwrite
-            }
-
+        var payload: Payload {
+            var content = Payload()
+            content["aps"] = .dictionary(aps.payload)
+            content["category"] = .string(category)
             return content
+        }
+
+        var userInfo: UserInfo {
+            payload
         }
     }
 
@@ -51,21 +46,33 @@ struct NotificationManagerTests {
             }
         }
 
-        if let content = aps1.userInfo {
-            let request = UserNotification.Request(content: UserNotification.Content(userInfo: content))
-            try notificationManager.localNotificationRequest(request)
-        }
+        var request = UserNotification.Request(
+            content: UserNotification.Content(
+                payload: aps1.payload,
+            ),
+        )
+        try notificationManager.localNotificationRequest(request)
+
+        try await Task.sleep(for: .milliseconds(150))
 
         let aPush = APushNotification(aps: aps2, category: "Testing")
-        let request2 = UserNotification.Request(content: UserNotification.Content(userInfo: aPush.userInfo))
-        try notificationManager.localNotificationRequest(request2)
+        request = UserNotification.Request(
+            content: UserNotification.Content(
+                payload: aPush.payload,
+            ),
+        )
+        try notificationManager.localNotificationRequest(request)
 
-        if let content = aps3.userInfo {
-            let request = UserNotification.Request(content: UserNotification.Content(userInfo: content))
-            try notificationManager.localNotificationRequest(request)
-        }
+        try await Task.sleep(for: .milliseconds(150))
 
-        try await Task.sleep(for: .milliseconds(1500))
+        request = UserNotification.Request(
+            content: UserNotification.Content(
+                payload: aps3.payload,
+            ),
+        )
+        try notificationManager.localNotificationRequest(request)
+
+        try await Task.sleep(for: .milliseconds(150))
 
         #expect(contentReceived == 3)
         #expect(notificationsReceived == 1)
@@ -85,20 +92,14 @@ struct NotificationManagerTests {
 
         try await Task.sleep(nanoseconds: 100_000_000)
 
-        if let payload = aps1.userInfo {
-            let request = UserNotification.Request(content: UserNotification.Content(userInfo: payload))
-            try notificationManager.localNotificationRequest(request)
-        }
+        var request = UserNotification.Request(content: UserNotification.Content(payload: aps1.payload))
+        try notificationManager.localNotificationRequest(request)
 
-        if let payload = aps2.userInfo {
-            let request = UserNotification.Request(content: UserNotification.Content(userInfo: payload))
-            try notificationManager.localNotificationRequest(request)
-        }
+        request = UserNotification.Request(content: UserNotification.Content(payload: aps2.payload))
+        try notificationManager.localNotificationRequest(request)
 
-        if let payload = aps3.userInfo {
-            let request = UserNotification.Request(content: UserNotification.Content(userInfo: payload))
-            try notificationManager.localNotificationRequest(request)
-        }
+        request = UserNotification.Request(content: UserNotification.Content(payload: aps3.payload))
+        try notificationManager.localNotificationRequest(request)
 
         try await Task.sleep(nanoseconds: 100_000_000)
 

--- a/Tests/NotificationTests/NotificationManagerTests.swift
+++ b/Tests/NotificationTests/NotificationManagerTests.swift
@@ -19,6 +19,7 @@ struct NotificationManagerTests {
             return content
         }
 
+        @available(*, deprecated)
         var userInfo: UserInfo {
             payload
         }
@@ -72,7 +73,7 @@ struct NotificationManagerTests {
         )
         try notificationManager.localNotificationRequest(request)
 
-        try await Task.sleep(for: .milliseconds(150))
+        try await Task.sleep(for: .seconds(1))
 
         #expect(contentReceived == 3)
         #expect(notificationsReceived == 1)
@@ -90,7 +91,7 @@ struct NotificationManagerTests {
             return output
         }
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(for: .seconds(1))
 
         var request = UserNotification.Request(content: UserNotification.Content(payload: aps1.payload))
         try notificationManager.localNotificationRequest(request)
@@ -101,7 +102,7 @@ struct NotificationManagerTests {
         request = UserNotification.Request(content: UserNotification.Content(payload: aps3.payload))
         try notificationManager.localNotificationRequest(request)
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(for: .seconds(1))
 
         subscription1.cancel()
         let traffic = try await subscription1.value

--- a/Tests/NotificationTests/NotificationManagerTests.swift
+++ b/Tests/NotificationTests/NotificationManagerTests.swift
@@ -73,7 +73,7 @@ struct NotificationManagerTests {
         )
         try notificationManager.localNotificationRequest(request)
 
-        try await Task.sleep(for: .seconds(1))
+        try await Task.sleep(for: .seconds(1.5))
 
         #expect(contentReceived == 3)
         #expect(notificationsReceived == 1)

--- a/Tests/NotificationTests/PayloadTests.swift
+++ b/Tests/NotificationTests/PayloadTests.swift
@@ -15,7 +15,7 @@ struct PayloadTests {
             "meeting_id": "mtg_404",
         ]
 
-        let payload = try UserNotification.Payload(userInfo: userInfo)
+        let payload = try Payload(userInfo: userInfo)
 
         #expect(payload == [
             "aps": .dictionary([
@@ -43,7 +43,7 @@ struct PayloadTests {
             "shared_by_user_id": "usr_123",
         ]
 
-        let payload = try UserNotification.Payload(userInfo: userInfo)
+        let payload = try Payload(userInfo: userInfo)
 
         #expect(payload == [
             "aps": .dictionary([


### PR DESCRIPTION
Moves `UserNotification.Payload` to the top-level Entity `Payload`.

Added the protocols `ExpressibleByPayload` and `PayloadConvertible` to offer conveniences and declaration of `Payload` interactions.

Remaining `userInfo` properties are deprecated.