### PR TITLE
Logger Metadata/MetadataValue

### DIFF
--- a/Sources/Notification/Extensions/DateComponents+Notification.swift
+++ b/Sources/Notification/Extensions/DateComponents+Notification.swift
@@ -1,0 +1,34 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+
+extension DateComponents {
+    var metadataValue: Logger.MetadataValue {
+        var content = Logger.Metadata()
+        if let year {
+            content["year"] = .stringConvertible(year)
+        }
+        if let month {
+            content["month"] = .stringConvertible(month)
+        }
+        if let day {
+            content["day"] = .stringConvertible(day)
+        }
+        if let hour {
+            content["hour"] = .stringConvertible(hour)
+        }
+        if let minute {
+            content["minute"] = .stringConvertible(minute)
+        }
+        if let second {
+            content["second"] = .stringConvertible(second)
+        }
+        if let nanosecond {
+            content["nanosecond"] = .stringConvertible(nanosecond)
+        }
+        return .dictionary(content)
+    }
+}

--- a/Sources/Notification/Firebase/FCMOptions.swift
+++ b/Sources/Notification/Firebase/FCMOptions.swift
@@ -1,4 +1,8 @@
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A dictionary FCM uses to pass features like the image URL. Your extension intercepts this payload,
 /// reads userInfo["fcm_options"]["image"], downloads the image, and attaches it before iOS displays

--- a/Sources/Notification/Payload.swift
+++ b/Sources/Notification/Payload.swift
@@ -7,6 +7,16 @@ import Logging
 
 public typealias Payload = [String: PayloadValue]
 
+/// A type which can be represented as a type-safe hashable/sendable dictionary.
+public protocol PayloadConvertible {
+    var payload: Payload { get }
+}
+
+/// A type which can be initialized with a type-safe hashable/sendable dictionary.
+public protocol ExpressibleByPayload {
+    init(payload: Payload) throws
+}
+
 public enum PayloadValue: Hashable, Sendable {
     case bool(Bool)
     case data(Data)
@@ -93,14 +103,4 @@ public extension Payload {
     var metadata: Logger.Metadata {
         mapValues(\.metadataValue)
     }
-}
-
-/// A type which can be represented as a type-safe hashable/sendable dictionary.
-public protocol PayloadConvertible {
-    var payload: Payload { get }
-}
-
-/// A type which can be initialized with a type-safe hashable/sendable dictionary.
-public protocol ExpressibleByPayload {
-    init(payload: Payload) throws
 }

--- a/Sources/Notification/Types/UserNotification+Action.swift
+++ b/Sources/Notification/Types/UserNotification+Action.swift
@@ -1,3 +1,5 @@
+import Logging
+
 public extension UserNotification {
     struct Action: Hashable, Sendable, Identifiable, Codable {
         /// The unique identifier for this action.
@@ -24,19 +26,15 @@ public extension UserNotification {
             self.destructive = destructive
             self.foreground = foreground
         }
-    }
-}
 
-extension UserNotification.Action: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Action {
-          id: \(id)
-          title: \(title)
-          authenticationRequired: \(authenticationRequired ? "YES" : "NO")
-          destructive: \(destructive ? "YES" : "NO")
-          foreground: \(foreground ? "YES" : "NO")
+        public var metadata: Logger.Metadata {
+            [
+                "id": .string(id),
+                "title": .string(title),
+                "authenticationRequired": .stringConvertible(authenticationRequired),
+                "destructive": .stringConvertible(destructive),
+                "foreground": .stringConvertible(foreground),
+            ]
         }
-        """
     }
 }

--- a/Sources/Notification/Types/UserNotification+Attachment.swift
+++ b/Sources/Notification/Types/UserNotification+Attachment.swift
@@ -1,4 +1,9 @@
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#else
 import Foundation
+#endif
+import Logging
 
 public extension UserNotification {
     struct Attachment: Hashable, Sendable, Identifiable {
@@ -20,17 +25,13 @@ public extension UserNotification {
             self.url = url
             self.type = type
         }
-    }
-}
 
-extension UserNotification.Attachment: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Attachment {
-          id: \(id)
-          url: \(url.absoluteString)
-          type: \(type)
+        public var metadata: Logger.Metadata {
+            [
+                "id": .string(id),
+                "url": .stringConvertible(url),
+                "type": .string(type),
+            ]
         }
-        """
     }
 }

--- a/Sources/Notification/Types/UserNotification+Attachment.swift
+++ b/Sources/Notification/Types/UserNotification+Attachment.swift
@@ -1,5 +1,5 @@
-#if canImport(FoundationNetworking)
-import FoundationNetworking
+#if canImport(FoundationEssentials)
+import FoundationEssentials
 #else
 import Foundation
 #endif

--- a/Sources/Notification/Types/UserNotification+Category.swift
+++ b/Sources/Notification/Types/UserNotification+Category.swift
@@ -1,3 +1,5 @@
+import Logging
+
 public extension UserNotification {
     struct Category: Hashable, Sendable, Identifiable, Codable {
 
@@ -11,18 +13,12 @@ public extension UserNotification {
             self.id = id
             self.actions = actions
         }
-    }
-}
 
-extension UserNotification.Category: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Category {
-          id: \(id)
-          actions: [
-            \(actions.map(\.debugDescription))
-          ]
+        public var metadata: Logger.Metadata {
+            [
+                "id": .string(id),
+                "actions": .array(actions.map { .dictionary($0.metadata) }),
+            ]
         }
-        """
     }
 }

--- a/Sources/Notification/Types/UserNotification+Content.swift
+++ b/Sources/Notification/Types/UserNotification+Content.swift
@@ -1,3 +1,5 @@
+import Logging
+
 public extension UserNotification {
     struct Content: Hashable, Sendable {
         /// Optional array of attachments.
@@ -73,6 +75,26 @@ public extension UserNotification {
             self.title = title
             payload = try Notification.Payload(userInfo: userInfo)
         }
+
+        public var metadata: Logger.Metadata {
+            var content: Logger.Metadata = [
+                "attachments": .array(attachments.map { .dictionary($0.metadata) }),
+                "body": .string(body),
+                "categoryId": .string(categoryId),
+                "launchImageName": .string(launchImageName),
+                "subtitle": .string(subtitle),
+                "threadIdentifier": .string(threadIdentifier),
+                "title": .string(title),
+                "payload": .dictionary(payload.metadata),
+            ]
+            if let badge {
+                content["badge"] = .stringConvertible(badge)
+            }
+            if let sound {
+                content["sound"] = sound.metadataValue
+            }
+            return content
+        }
     }
 }
 
@@ -89,26 +111,5 @@ public extension UserNotification.Content {
         }
 
         return try? APS(dictionary: dictionary)
-    }
-}
-
-extension UserNotification.Content: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Content {
-          attachments: [
-            \(attachments.map(\.debugDescription))
-          ]
-          badge: \(badge?.description ?? "NIL")
-          body: \(body)
-          categoryId: \(categoryId)
-          launchImageName: \(launchImageName)
-          sound: \(sound?.debugDescription ?? "NIL")
-          subtitle: \(subtitle)
-          threadIdentifier: \(threadIdentifier)
-          title: \(title)
-          payload: \(payload.debugDescription)
-        }
-        """
     }
 }

--- a/Sources/Notification/Types/UserNotification+Request.swift
+++ b/Sources/Notification/Types/UserNotification+Request.swift
@@ -1,3 +1,5 @@
+import Logging
+
 public extension UserNotification {
     struct Request: Hashable, Sendable, Identifiable {
         public let id: String
@@ -13,17 +15,16 @@ public extension UserNotification {
             self.content = content
             self.trigger = trigger
         }
-    }
-}
 
-extension UserNotification.Request: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Request {
-          id: \(id)
-          content: \(content.debugDescription)
-          trigger: \(trigger?.debugDescription ?? "NIL")
+        public var metadata: Logger.Metadata {
+            var output: Logger.Metadata = [
+                "id": .string(id),
+                "content": .dictionary(content.payload.metadata),
+            ]
+            if let trigger {
+                output["trigger"] = .dictionary(trigger.metadata)
+            }
+            return output
         }
-        """
     }
 }

--- a/Sources/Notification/Types/UserNotification+Sound.swift
+++ b/Sources/Notification/Types/UserNotification+Sound.swift
@@ -1,3 +1,5 @@
+import Logging
+
 public extension UserNotification {
     enum Sound: Hashable, Sendable {
         /// Default alerts
@@ -41,17 +43,35 @@ public extension UserNotification {
                 nil
             }
         }
-    }
-}
 
-extension UserNotification.Sound: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Sound {
-          name: \(name ?? "NIL")
-          isDefault: \(isDefault ? "YES" : "NO")
-          isCritical: \(isCritical ? "YES" : "NO")
+        public var metadataValue: Logger.MetadataValue {
+            switch self {
+            case .default:
+                .string("default")
+            case .named(let string):
+                .dictionary(["named": .string(string)])
+            case .critical(let name, let volume):
+                switch (name, volume) {
+                case (.some(let criticalName), .some(let criticalVolume)):
+                    .dictionary([
+                        "name": .string(criticalName),
+                        "volume": .stringConvertible(criticalVolume),
+                    ])
+                case (.some(let criticalName), .none):
+                    .dictionary([
+                        "name": .string(criticalName),
+                    ])
+                case (.none, .some(let criticalVolume)):
+                    .dictionary([
+                        "name": .string("critical"),
+                        "volume": .stringConvertible(criticalVolume),
+                    ])
+                case (.none, .none):
+                    .dictionary([
+                        "name": .string("critical"),
+                    ])
+                }
+            }
         }
-        """
     }
 }

--- a/Sources/Notification/Types/UserNotification+Trigger.swift
+++ b/Sources/Notification/Types/UserNotification+Trigger.swift
@@ -3,6 +3,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
+import Logging
 
 public extension UserNotification {
     struct Trigger: Hashable, Sendable {
@@ -11,6 +12,17 @@ public extension UserNotification {
             case push
             case timeInterval(TimeInterval)
             case calendar(DateComponents)
+
+            public var metadataValue: Logger.MetadataValue {
+                switch self {
+                case .push:
+                    .string("push")
+                case .timeInterval(let timeInterval):
+                    .dictionary(["interval": .stringConvertible(timeInterval)])
+                case .calendar(let dateComponents):
+                    .dictionary(["calendar": dateComponents.metadataValue])
+                }
+            }
         }
 
         public let event: Event?
@@ -23,29 +35,14 @@ public extension UserNotification {
             self.event = event
             self.repeats = repeats
         }
-    }
-}
 
-extension UserNotification.Trigger: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification.Trigger {
-          event: \(event?.debugDescription ?? "NIL")
-          repeats: \(repeats ? "YES" : "NO")
-        }
-        """
-    }
-}
-
-extension UserNotification.Trigger.Event: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        switch self {
-        case .push:
-            "UserNotification.Trigger.Event { Push }"
-        case .timeInterval(let timeInterval):
-            "UserNotification.Trigger.Event { Time Interval - \(timeInterval) }"
-        case .calendar(let dateComponents):
-            "UserNotification.Trigger.Event { Date Components - \(dateComponents) }"
+        public var metadata: Logger.Metadata {
+            var content = Logger.Metadata()
+            if let event {
+                content["event"] = event.metadataValue
+            }
+            content["repeats"] = .stringConvertible(repeats)
+            return content
         }
     }
 }

--- a/Sources/Notification/Types/UserNotification.swift
+++ b/Sources/Notification/Types/UserNotification.swift
@@ -16,14 +16,3 @@ public struct UserNotification: Hashable, Sendable {
         self.request = request
     }
 }
-
-extension UserNotification: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        """
-        UserNotification {
-          date: \(date.debugDescription)
-          request: \(request.debugDescription)
-        }
-        """
-    }
-}


### PR DESCRIPTION
Removed the `CustomStringConvertible`/`CustomDebugStringConvertible` implementations in favor of Logger.Metadata/MetadataValue access. This allows for easier logging of library types.