### PR TITLE
Payload Value Checks

### DIFF
--- a/Sources/Notification/Payload.swift
+++ b/Sources/Notification/Payload.swift
@@ -28,7 +28,24 @@ public enum PayloadValue: Hashable, Sendable {
     case dictionary([String: PayloadValue])
 
     public init(_ any: Any) throws {
+        let isBool = String(describing: type(of: any)) == "__NSCFBoolean"
+        var isInt = false
+        var isFloat = false
+        #if canImport(Foundation)
+        if let nsNumber = any as? NSNumber {
+            let numberType = CFNumberGetType(nsNumber)
+            isInt = [.intType, .sInt8Type, .sInt16Type, .sInt32Type, .sInt64Type, .nsIntegerType].contains(numberType)
+            isFloat = [.floatType, .float32Type, .float64Type, .cgFloatType, .doubleType].contains(numberType)
+        }
+        #endif
+
         switch any {
+        case let value as Bool where isBool:
+            self = .bool(value)
+        case let value as Double where isFloat:
+            self = .double(value)
+        case let value as Int where isInt:
+            self = .int(value)
         case let value as Bool:
             self = .bool(value)
         case let value as Data:

--- a/Sources/Notification/Payload.swift
+++ b/Sources/Notification/Payload.swift
@@ -31,11 +31,11 @@ public enum PayloadValue: Hashable, Sendable {
         let isBool = String(describing: type(of: any)) == "__NSCFBoolean"
         var isInt = false
         var isFloat = false
-        #if canImport(Foundation)
+        #if canImport(ObjectiveC)
         if let nsNumber = any as? NSNumber {
             let numberType = CFNumberGetType(nsNumber)
-            isInt = [.intType, .sInt8Type, .sInt16Type, .sInt32Type, .sInt64Type, .nsIntegerType].contains(numberType)
-            isFloat = [.floatType, .float32Type, .float64Type, .cgFloatType, .doubleType].contains(numberType)
+            isInt = [CFNumberType.intType, .sInt8Type, .sInt16Type, .sInt32Type, .sInt64Type, .nsIntegerType].contains(numberType)
+            isFloat = [CFNumberType.floatType, .float32Type, .float64Type, .cgFloatType, .doubleType].contains(numberType)
         }
         #endif
 

--- a/Tests/NotificationTests/PayloadTests.swift
+++ b/Tests/NotificationTests/PayloadTests.swift
@@ -70,15 +70,15 @@ struct PayloadTests {
         ]
 
         var userInfo: UserInfo = [
-            "bool" : false,
-            "int" : 3,
-            "double" : 3.33,
+            "bool": false,
+            "int": 3,
+            "double": 3.33,
         ]
 
         var payload = try Payload(userInfo: userInfo)
         #expect(payload == result)
 
-        #if canImport(Foundation)
+        #if canImport(ObjectiveC)
         userInfo["bool"] = NSNumber(booleanLiteral: false)
         payload = try Payload(userInfo: userInfo)
         #expect(payload == result)

--- a/Tests/NotificationTests/PayloadTests.swift
+++ b/Tests/NotificationTests/PayloadTests.swift
@@ -1,3 +1,6 @@
+#if canImport(Foundation)
+import Foundation
+#endif
 @testable import Notification
 import Testing
 
@@ -57,5 +60,32 @@ struct PayloadTests {
             "document_id": .string("doc_8675309"),
             "shared_by_user_id": .string("usr_123"),
         ])
+    }
+
+    @Test func mixedValues() throws {
+        let result: Payload = [
+            "bool": .bool(false),
+            "int": .int(3),
+            "double": .double(3.33),
+        ]
+
+        var userInfo: UserInfo = [
+            "bool" : false,
+            "int" : 3,
+            "double" : 3.33,
+        ]
+
+        var payload = try Payload(userInfo: userInfo)
+        #expect(payload == result)
+
+        #if canImport(Foundation)
+        userInfo["bool"] = NSNumber(booleanLiteral: false)
+        payload = try Payload(userInfo: userInfo)
+        #expect(payload == result)
+
+        userInfo["int"] = NSNumber(integerLiteral: 3)
+        payload = try Payload(userInfo: userInfo)
+        #expect(payload == result)
+        #endif
     }
 }


### PR DESCRIPTION
The initial approach to initializing `PayloadValue` was a bit naïve, as booleans, integers, and doubles can all be represented through `NSNumber`, which can then always convert to checked types.